### PR TITLE
Add CMOR handlers for MPAS-Seaice output

### DIFF
--- a/CMOR_NOTES.md
+++ b/CMOR_NOTES.md
@@ -2,7 +2,7 @@
 
 ## 2D
 
-| variable   | handler | run | checked | sample_path | 
+| variable   | handler | run | checked | sample_path |
 | --------   | ------- | --- | ------- | ----------- |
 | tas        | YES     | no  | no      | no          |
 | ts         | YES     | no  | no      | no          |
@@ -59,3 +59,64 @@
 | ua       | no      | no  | no      | no          |
 | va       | no      | no  | no      | no          |
 | zg       | no      | no  | no      | no          |
+
+
+# OCN variable handlers
+
+## Scalar
+
+| variable   | handler | run | checked | sample_path |
+| --------   | ------- | --- | ------- | ----------- |
+| masso      | YES     | no  | no      | no          |
+| volo       | YES     | no  | no      | no          |
+| thetaoga   | YES     | no  | no      | no          |
+| tosga      | YES     | no  | no      | no          |
+| soga       | YES     | no  | no      | no          |
+| sosga      | YES     | no  | no      | no          |
+
+
+## 1D
+
+| variable   | handler | run | checked | sample_path |
+| --------   | ------- | --- | ------- | ----------- |
+| hfbasin    | NO      | no  | no      | no          |
+
+
+## 2D
+
+| variable   | handler | run | checked | sample_path |
+| --------   | ------- | --- | ------- | ----------- |
+| pbo        | YES     | no  | no      | no          |
+| pso        | YES     | no  | no      | no          |
+| zos        | YES     | no  | no      | no          |
+| masscello  | YES     | no  | no      | no          |
+| tos        | YES     | no  | no      | no          |
+| tob        | YES     | no  | no      | no          |
+| sos        | YES     | no  | no      | no          |
+| sob        | YES     | no  | no      | no          |
+| mlotst     | YES     | no  | no      | no          |
+| msftmz     | YES     | no  | no      | no          |
+| fsitherm   | YES     | no  | no      | no          |
+| wfo        | YES     | no  | no      | no          |
+| sfdsi      | YES     | no  | no      | no          |
+| hfds       | YES     | no  | no      | no          |
+| tauuo      | YES     | no  | no      | no          |
+| tauvo      | YES     | no  | no      | no          |
+
+## 3D model level
+
+| variable   | handler | run | checked | sample_path |
+| --------   | ------- | --- | ------- | ----------- |
+| thetao     | YES     | no  | no      | no          |
+| so         | YES     | no  | no      | no          |
+| uo         | YES     | no  | no      | no          |
+| vo         | YES     | no  | no      | no          |
+| wo         | YES     | no  | no      | no          |
+| hfsifrazil | NO      | no  | no      | no          |
+
+## 3D olevhalf
+
+| variable | handler | run | checked | sample_path |
+| -------- | ------- | --- | ------- | ----------- |
+| zhalfo   | YES     | no  | no      | no          |
+

--- a/CMOR_NOTES.md
+++ b/CMOR_NOTES.md
@@ -112,7 +112,7 @@
 | uo         | YES     | no  | no      | no          |
 | vo         | YES     | no  | no      | no          |
 | wo         | YES     | no  | no      | no          |
-| hfsifrazil | NO      | no  | no      | no          |
+| hfsifrazil | YES     | no  | no      | no          |
 
 ## 3D olevhalf
 
@@ -120,3 +120,19 @@
 | -------- | ------- | --- | ------- | ----------- |
 | zhalfo   | YES     | no  | no      | no          |
 
+
+# ICE variable handlers
+
+## 2D
+
+| variable   | handler | run | checked | sample_path |
+| --------   | ------- | --- | ------- | ----------- |
+| sitimefrac | YES     | no  | no      | no          |
+| siconc     | YES     | no  | no      | no          |
+| simass     | YES     | no  | no      | no          |
+| sithick    | YES     | no  | no      | no          |
+| sisnmass   | YES     | no  | no      | no          |
+| sisnthick  | YES     | no  | no      | no          |
+| sitemptop  | YES     | no  | no      | no          |
+| siu        | YES     | no  | no      | no          |
+| siv        | YES     | no  | no      | no          |

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ optional arguments:
   --version             print the version number and exit
   --debug               Set output level to debug
 ```
+
+## conda environment
+
+To create a conda environment with the required dependencies, run:
+```
+conda create -n e3sm_to_cmip -c conda-forge nco cmor cdutil cdms2 progressbar2 pyyaml xarray \
+    netcdf4 dask scipy
+```
+
+You can also install the `e3sm_to_cmip` conda package directly from the `e3sm` channel:
+```
+conda create -n e3sm_to_cmip -c conda-forge -c e3sm e3sm_to_cmip
+```
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,19 +18,22 @@ about:
     Climate Model Output Rewritter.
 
 requirements:
-  build:
+  host:
     - python
+    - pip
     - setuptools
 
   run:
     - nco
-    - pip
-    - python
-    - setuptools
     - cmor
     - cdutil
     - cdms2 >=3.1
-    - tqdm
+    - progressbar2
+    - pyyaml
+    - xarray
+    - netcdf4
+    - dask
+    - scipy
 
 test:
   imports:

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import sys
 import logging
+import tempfile
+import shutil
 
 from multiprocessing import cpu_count, Pool
 from time import sleep
@@ -59,6 +61,13 @@ def main():
     # create the output dir if it doesnt exist
     if not os.path.exists(output_path):
         os.makedirs(output_path)
+
+    temp_path = '{}/tmp'.format(output_path)
+
+    if not os.path.exists(temp_path):
+        os.makedirs(temp_path)
+
+    tempfile.tempdir = temp_path
 
     logging_path = os.path.join(output_path, 'converter.log')
     print_message("Writing log output to: {}".format(logging_path), 'debug')
@@ -131,6 +140,8 @@ def main():
         add_metadata(
             file_path=output_path,
             var_list=var_list)
+
+    shutil.rmtree(temp_path)
     return 0
 # ------------------------------------------------------------------
 

--- a/e3sm_to_cmip/cmor_handlers/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/fsitherm.py
@@ -1,0 +1,75 @@
+
+"""
+compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'fsitherm'
+VAR_UNITS = 'kg m-2 s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_seaIceFreshWaterFlux into CMIP.fsitherm
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_seaIceFreshWaterFlux',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_seaIceFreshWaterFlux
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/fsitherm.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'fsitherm'
 VAR_UNITS = 'kg m-2 s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/hfds.py
@@ -1,0 +1,88 @@
+
+"""
+compute Downward Heat Flux at Sea Water Surface, hfds
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'hfds'
+VAR_UNITS = 'W m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_seaIceHeatFlux,
+    timeMonthly_avg_latentHeatFlux ,timeMonthly_avg_sensibleHeatFlux,
+    timeMonthly_avg_shortWaveHeatFlux, timeMonthly_avg_longWaveHeatFluxUp, and
+    timeMonthly_avg_longWaveHeatFluxDown into CMIP.hfds
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_seaIceHeatFlux',
+                    'timeMonthly_avg_latentHeatFlux',
+                    'timeMonthly_avg_sensibleHeatFlux',
+                    'timeMonthly_avg_shortWaveHeatFlux',
+                    'timeMonthly_avg_longWaveHeatFluxUp',
+                    'timeMonthly_avg_longWaveHeatFluxDown',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = (dsIn.timeMonthly_avg_seaIceHeatFlux +
+                        dsIn.timeMonthly_avg_latentHeatFlux +
+                        dsIn.timeMonthly_avg_sensibleHeatFlux +
+                        dsIn.timeMonthly_avg_shortWaveHeatFlux +
+                        dsIn.timeMonthly_avg_longWaveHeatFluxUp +
+                        dsIn.timeMonthly_avg_longWaveHeatFluxDown)
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS, positive='down')
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/hfds.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'hfds'
 VAR_UNITS = 'W m-2'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'hfsifrazil'
 VAR_UNITS = 'W m-2'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
@@ -1,0 +1,95 @@
+
+"""
+compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'hfsifrazil'
+VAR_UNITS = 'W m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_frazilLayerThicknessTendency into
+    CMIP.hfsifrazil
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    timeSeriesFiles = infiles['MPASO']
+    mappingFileName = infiles['MPAS_map']
+    meshFileName = infiles['MPAS_mesh']
+    namelistFileName = infiles['MPASO_namelist']
+
+    namelist = mpas.convert_namelist_to_dict(namelistFileName)
+    config_density0 = float(namelist['config_density0'])
+    config_frazil_heat_of_fusion = \
+        float(namelist['config_frazil_heat_of_fusion'])
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_frazilLayerThicknessTendency',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = -config_density0 * config_frazil_heat_of_fusion * \
+            dsIn.timeMonthly_avg_frazilLayerThicknessTendency
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS, positive='down')
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/masscello.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'masscello'
 VAR_UNITS = 'kg m-2'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/masscello.py
@@ -1,0 +1,90 @@
+
+"""
+compute Ocean Grid-Cell Mass per area, masscello
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'masscello'
+VAR_UNITS = 'kg m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness into CMIP.masscello
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    namelistFileName = infiles['MPASO_namelist']
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    namelist = mpas.convert_namelist_to_dict(namelistFileName)
+    config_density0 = float(namelist['config_density0'])
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = config_density0 * \
+            dsIn.timeMonthly_avg_layerThickness.where(cellMask3D)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/masso.py
@@ -1,0 +1,74 @@
+
+"""
+compute Sea Water Mass, masso
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'masso'
+VAR_UNITS = 'kg'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness into CMIP.masso
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    namelistFileName = infiles['MPASO_namelist']
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    namelist = mpas.convert_namelist_to_dict(namelistFileName)
+    config_density0 = float(namelist['config_density0'])
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = (config_density0 *
+                        dsIn.timeMonthly_avg_layerThickness.where(cellMask3D) *
+                        dsMesh.areaCell).sum(dim=['nVertLevels', 'nCells'])
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/masso.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'masso'
 VAR_UNITS = 'kg'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mlotst.py
@@ -1,0 +1,80 @@
+
+"""
+compute Ocean Mixed Layer Thickness Defined by Sigma T, mlotst
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'mlotst'
+VAR_UNITS = 'm'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_tThreshMLD into CMIP.mlotst
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_tThreshMLD',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_tThreshMLD.where(cellMask2D)
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mlotst.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'mlotst'
 VAR_UNITS = 'm'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/msftmz.py
@@ -1,0 +1,91 @@
+
+"""
+compute Ocean Meridional Overturning Mass Streamfunction, msftmz
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPASO_MOC_regions']
+
+# output variable name
+VAR_NAME = 'msftmz'
+VAR_UNITS = 'kg s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_normalVelocity,
+    timeMonthly_avg_normalGMBolusVelocity, timeMonthly_avg_vertVelocityTop,
+    timeMonthly_avg_vertGMBolusVelocityTop, and timeMonthly_avg_layerThickness
+    into CMIP.msftmz
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+    regionMaskFileName = infiles['MPASO_MOC_regions']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    dsMesh = dsMesh.isel(Time=0)
+
+    dsMasks = xarray.open_dataset(regionMaskFileName, mask_and_scale=False)
+
+    variableList = ['timeMonthly_avg_normalVelocity',
+                    'timeMonthly_avg_normalGMBolusVelocity',
+                    'timeMonthly_avg_vertVelocityTop',
+                    'timeMonthly_avg_vertGMBolusVelocityTop',
+                    'timeMonthly_avg_layerThickness',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        showProgress = 'serial' in kwargs and kwards['serial']
+        ds = mpas.compute_moc_streamfunction(dsIn, dsMesh, dsMasks,
+                                             showProgress=showProgress)
+    ds = ds.rename({'moc': VAR_NAME})
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    region = ['global_ocean',
+              'atlantic_arctic_ocean']
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'basin',
+             'units': '',
+             'coord_vals': region},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/msftmz.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPASO_MOC_regions']
 # output variable name
 VAR_NAME = 'msftmz'
 VAR_UNITS = 'kg s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/pbo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
 # output variable name
 VAR_NAME = 'pbo'
 VAR_UNITS = 'Pa'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/pbo.py
@@ -1,0 +1,98 @@
+
+"""
+compute Sea Water Pressure at Sea floor, pbo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
+
+# output variable name
+VAR_NAME = 'pbo'
+VAR_UNITS = 'Pa'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_pressureAdjustedSSH, timeMonthly_avg_ssh,
+    timeMonthly_avg_density, timeMonthly_avg_layerThickness, and EAM PSL into
+    CMIP.pbo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    namelistFileName = infiles['MPASO_namelist']
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+    pslFileNames = infiles['PSL']
+
+    namelist = mpas.convert_namelist_to_dict(namelistFileName)
+    config_density0 = float(namelist['config_density0'])
+    gravity = 9.80616
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_pressureAdjustedSSH',
+                    'timeMonthly_avg_ssh', 'timeMonthly_avg_layerThickness',
+                    'timeMonthly_avg_density', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        seaIcePressure = config_density0 * gravity * \
+            (dsIn.timeMonthly_avg_pressureAdjustedSSH -
+             dsIn.timeMonthly_avg_ssh)
+        ds[VAR_NAME] = seaIcePressure.where(cellMask2D) + gravity * \
+            (dsIn.timeMonthly_avg_density *
+             dsIn.timeMonthly_avg_layerThickness).where(cellMask3D).sum(
+                dim='nVertLevels')
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
+        ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/pso.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
 # output variable name
 VAR_NAME = 'pso'
 VAR_UNITS = 'Pa'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/pso.py
@@ -1,0 +1,94 @@
+
+"""
+compute Sea Water Pressure at Sea Water Surface, pso
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
+
+# output variable name
+VAR_NAME = 'pso'
+VAR_UNITS = 'Pa'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_pressureAdjustedSSH and
+    timeMonthly_avg_ssh, and EAM PSL into CMIP.pso
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    namelistFileName = infiles['MPASO_namelist']
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+    pslFileNames = infiles['PSL']
+
+    namelist = mpas.convert_namelist_to_dict(namelistFileName)
+    config_density0 = float(namelist['config_density0'])
+    gravity = 9.80616
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_pressureAdjustedSSH',
+                    'timeMonthly_avg_ssh', 'timeMonthly_avg_layerThickness',
+                    'timeMonthly_avg_density', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        seaIcePressure = config_density0 * gravity * \
+            (dsIn.timeMonthly_avg_pressureAdjustedSSH -
+             dsIn.timeMonthly_avg_ssh)
+        ds[VAR_NAME] = seaIcePressure.where(cellMask2D)
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
+        ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/sfdsi.py
@@ -1,0 +1,75 @@
+
+"""
+compute Downward Sea Ice Basal Salt Flux, sfdsi
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sfdsi'
+VAR_UNITS = 'kg m-2 s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_seaIceSalinityFlux into CMIP.sfdsi
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_seaIceSalinityFlux',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_seaIceSalinityFlux
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS, positive='down')
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/sfdsi.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sfdsi'
 VAR_UNITS = 'kg m-2 s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/siconc.py
@@ -1,0 +1,83 @@
+
+"""
+Sea-ice area fraction, siconc
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'siconc'
+VAR_UNITS = '%'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell into CMIP.siconc
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = 100.*dsIn.timeMonthly_avg_iceAreaCell
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/siconc.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'siconc'
 VAR_UNITS = '%'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/simass.py
@@ -1,0 +1,89 @@
+
+"""
+Sea-ice mass per area, simass
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'simass'
+VAR_UNITS = 'kg m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell and
+    timeMonthly_avg_iceVolumeCell into CMIP.simass
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    rhoi = 917.0
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_iceVolumeCell',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = rhoi*dsIn.timeMonthly_avg_iceVolumeCell
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/simass.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'simass'
 VAR_UNITS = 'kg m-2'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnmass.py
@@ -1,0 +1,89 @@
+
+"""
+Snow mass per area, sisnmass
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sisnmass'
+VAR_UNITS = 'kg m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell and
+    timeMonthly_avg_snowVolumeCell into CMIP.sisnmass
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    rhos = 330.0
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_snowVolumeCell',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = rhos*dsIn.timeMonthly_avg_snowVolumeCell
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnmass.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sisnmass'
 VAR_UNITS = 'kg m-2'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnthick.py
@@ -1,0 +1,87 @@
+
+"""
+Snow thickness, sisnthick
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sisnthick'
+VAR_UNITS = 'm'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell and
+    timeMonthly_avg_snowVolumeCell into CMIP.sisnthick
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_snowVolumeCell',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_snowVolumeCell
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnthick.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sisnthick'
 VAR_UNITS = 'm'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/sitemptop.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sitemptop'
 VAR_UNITS = 'K'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/sitemptop.py
@@ -1,0 +1,88 @@
+
+"""
+Surface temperature of sea ice, sitemptop
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sitemptop'
+VAR_UNITS = 'K'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell and
+    timeMonthly_avg_surfaceTemperatureCell into CMIP.sitemptop
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_surfaceTemperatureCell',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds[VAR_NAME] = ds['siconc'] * \
+            (dsIn.timeMonthly_avg_surfaceTemperatureCell + 273.15)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/sithick.py
@@ -1,0 +1,87 @@
+
+"""
+Sea-ice thickness, sithick
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sithick'
+VAR_UNITS = 'm'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_iceAreaCell and
+    timeMonthly_avg_iceVolumeCell into CMIP.sithick
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_iceVolumeCell',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_iceVolumeCell
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/sithick.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sithick'
 VAR_UNITS = 'm'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/sitimefrac.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sitimefrac'
 VAR_UNITS = '1'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/sitimefrac.py
@@ -1,0 +1,83 @@
+
+"""
+Fraction of time steps with sea ice, sitimefrac
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sitimefrac'
+VAR_UNITS = '1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_icePresent into CMIP.sitimefrac
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_icePresent', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_icePresent
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/siu.py
@@ -1,0 +1,88 @@
+
+"""
+X-component of sea ice velocity, siu
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'siu'
+VAR_UNITS = 'm s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_uVelocityGeo into CMIP.siu
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_uVelocityGeo', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds[VAR_NAME] = ds['siconc'] * mpas.interp_vertex_to_cell(
+            dsIn.timeMonthly_avg_uVelocityGeo, dsMesh)
+        ds = mpas.add_time(ds, dsIn)
+        ds = ds.chunk(chunks={'nCells': None, 'time': 6})
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/siu.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'siu'
 VAR_UNITS = 'm s-1'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/siv.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'siv'
 VAR_UNITS = 'm s-1'
+TABLE = 'CMIP6_SImon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/siv.py
@@ -1,0 +1,88 @@
+
+"""
+Y-component of sea ice velocity, siv
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'siv'
+VAR_UNITS = 'm s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASSI timeMonthly_avg_vVelocityGeo into CMIP.siv
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASSI']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_iceAreaCell',
+                    'timeMonthly_avg_vVelocityGeo', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds['siconc'] = dsIn.timeMonthly_avg_iceAreaCell
+        ds[VAR_NAME] = ds['siconc'] * mpas.interp_vertex_to_cell(
+            dsIn.timeMonthly_avg_vVelocityGeo, dsMesh)
+        ds = mpas.add_time(ds, dsIn)
+        ds = ds.chunk(chunks={'nCells': None, 'time': 6})
+        ds.compute()
+
+    ds = mpas.add_si_mask(ds, cellMask2D, ds.siconc)
+    ds['cellMask'] = ds.siconc * ds.cellMask
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/so.py
+++ b/e3sm_to_cmip/cmor_handlers/so.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'so'
 VAR_UNITS = '0.001'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/so.py
+++ b/e3sm_to_cmip/cmor_handlers/so.py
@@ -1,0 +1,85 @@
+
+"""
+compute Sea Water Salinity, so
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'so'
+VAR_UNITS = '0.001'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.so
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_salinity',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_activeTracers_salinity
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/sob.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sob'
 VAR_UNITS = '0.001'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/sob.py
@@ -1,0 +1,81 @@
+
+"""
+compute Sea Water Salinity at Sea Floor, sob
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sob'
+VAR_UNITS = '0.001'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sob
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_salinity',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_activeTracers_salinity
+        ds = mpas.get_sea_floor_values(ds, dsMesh)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/soga.py
@@ -1,0 +1,76 @@
+
+"""
+compute Global Mean Sea Water Salinity, soga
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'soga'
+VAR_UNITS = '0.001'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness and
+    timeMonthly_avg_activeTracers_salinity into CMIP.soga
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness',
+                    'timeMonthly_avg_activeTracers_salinity',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        layerThickness = dsIn.timeMonthly_avg_layerThickness.where(cellMask3D)
+        thetao = dsIn.timeMonthly_avg_activeTracers_salinity.where(
+            cellMask3D)
+        vol = layerThickness*dsMesh.areaCell
+        volo = (vol).sum(dim=['nVertLevels', 'nCells'])
+        ds[VAR_NAME] = (vol*thetao).sum(dim=['nVertLevels', 'nCells'])/volo
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/soga.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'soga'
 VAR_UNITS = '0.001'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/sos.py
@@ -1,0 +1,81 @@
+
+"""
+compute Sea Surface Salinity, sos
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'sos'
+VAR_UNITS = '0.001'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sos
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_salinity',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        thetao = dsIn.timeMonthly_avg_activeTracers_salinity
+        ds[VAR_NAME] = thetao.isel(nVertLevels=0).squeeze(drop=True)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/sos.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'sos'
 VAR_UNITS = '0.001'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/sosga.py
@@ -1,0 +1,72 @@
+
+"""
+compute Global Average Sea Surface Salinity, sosga
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'sosga'
+VAR_UNITS = '0.001'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sosga
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_salinity',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        thetao = dsIn.timeMonthly_avg_activeTracers_salinity
+        tos = thetao.isel(nVertLevels=0).squeeze(drop=True).where(cellMask2D)
+        areaCell = dsMesh.areaCell.where(cellMask2D)
+        ds[VAR_NAME] = ((tos*areaCell).sum(dim='nCells') /
+                        areaCell.sum(dim='nCells'))
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/sosga.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'sosga'
 VAR_UNITS = '0.001'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/tauuo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'tauuo'
 VAR_UNITS = 'N m-2'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/tauuo.py
@@ -1,0 +1,75 @@
+
+"""
+compute Surface Downward X Stress, tauuo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'tauuo'
+VAR_UNITS = 'N m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_windStressZonal into CMIP.tauuo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_windStressZonal',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_windStressZonal
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS, positive='down')
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/tauvo.py
@@ -1,0 +1,75 @@
+
+"""
+compute Surface Downward Y Stress, tauvo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'tauvo'
+VAR_UNITS = 'N m-2'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_windStressMeridional into CMIP.tauvo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_windStressMeridional',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_windStressMeridional
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS, positive='down')
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/tauvo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'tauvo'
 VAR_UNITS = 'N m-2'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/thetao.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'thetao'
 VAR_UNITS = 'degC'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/thetao.py
@@ -1,0 +1,85 @@
+
+"""
+compute Sea Water Potential Temperature, thetao
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'thetao'
+VAR_UNITS = 'degC'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.thetao
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_temperature',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_activeTracers_temperature
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/thetaoga.py
@@ -1,0 +1,76 @@
+
+"""
+compute Global Average Sea Water Potential Temperature, thetaoga
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'thetaoga'
+VAR_UNITS = 'degC'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness and
+    timeMonthly_avg_activeTracers_temperature into CMIP.thetaoga
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness',
+                    'timeMonthly_avg_activeTracers_temperature',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        layerThickness = dsIn.timeMonthly_avg_layerThickness.where(cellMask3D)
+        thetao = dsIn.timeMonthly_avg_activeTracers_temperature.where(
+            cellMask3D)
+        vol = layerThickness*dsMesh.areaCell
+        volo = (vol).sum(dim=['nVertLevels', 'nCells'])
+        ds[VAR_NAME] = (vol*thetao).sum(dim=['nVertLevels', 'nCells'])/volo
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/thetaoga.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'thetaoga'
 VAR_UNITS = 'degC'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/tob.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'tob'
 VAR_UNITS = 'degC'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/tob.py
@@ -1,0 +1,81 @@
+
+"""
+compute Sea Water Potential Temperature at Sea Floor, tob
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'tob'
+VAR_UNITS = 'degC'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tob
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_temperature',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_activeTracers_temperature
+        ds = mpas.get_sea_floor_values(ds, dsMesh)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/tos.py
@@ -1,0 +1,81 @@
+
+"""
+compute Sea Surface Temperature, tos
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'tos'
+VAR_UNITS = 'degC'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tos
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_temperature',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        thetao = dsIn.timeMonthly_avg_activeTracers_temperature
+        ds[VAR_NAME] = thetao.isel(nVertLevels=0).squeeze(drop=True)
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask2D)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/tos.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'tos'
 VAR_UNITS = 'degC'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/tosga.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'tosga'
 VAR_UNITS = 'degC'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/tosga.py
@@ -1,0 +1,72 @@
+
+"""
+compute Global Average Sea Surface Temperature, tosga
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'tosga'
+VAR_UNITS = 'degC'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tosga
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_activeTracers_temperature',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        thetao = dsIn.timeMonthly_avg_activeTracers_temperature
+        tos = thetao.isel(nVertLevels=0).squeeze(drop=True).where(cellMask2D)
+        areaCell = dsMesh.areaCell.where(cellMask2D)
+        ds[VAR_NAME] = ((tos*areaCell).sum(dim='nCells') /
+                        areaCell.sum(dim='nCells'))
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/uo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'uo'
 VAR_UNITS = 'm s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/uo.py
@@ -1,0 +1,85 @@
+
+"""
+compute Sea Water X Velocity, uo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'uo'
+VAR_UNITS = 'm s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_velocityZonal into CMIP.uo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_velocityZonal',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_velocityZonal
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/vo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'vo'
 VAR_UNITS = 'm s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/vo.py
@@ -1,0 +1,85 @@
+
+"""
+compute Sea Water Y Velocity, vo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'vo'
+VAR_UNITS = 'm s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_velocityMeridional into CMIP.vo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_velocityMeridional',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_velocityMeridional
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = mpas.add_depth(ds, dsMesh)
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord',
+             'units': 'm',
+             'coord_vals': ds.depth.values,
+             'cell_bounds': ds.depth_bnds.values},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/volo.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
 # output variable name
 VAR_NAME = 'volo'
 VAR_UNITS = 'm3'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/volo.py
@@ -1,0 +1,72 @@
+
+"""
+compute Sea Water Volume, volo
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
+
+# output variable name
+VAR_NAME = 'volo'
+VAR_UNITS = 'm3'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness into CMIP.volo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
+                    'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = (dsIn.timeMonthly_avg_layerThickness.where(cellMask3D) *
+                        dsMesh.areaCell).sum(dim=['nVertLevels', 'nCells'])
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds.compute()
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/wfo.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_map']
 # output variable name
 VAR_NAME = 'wfo'
 VAR_UNITS = 'kg m-2 s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/wfo.py
@@ -1,0 +1,85 @@
+
+"""
+compute Water Flux into Sea Water, wfo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'wfo'
+VAR_UNITS = 'kg m-2 s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_seaIceFreshWaterFlux,
+    timeMonthly_avg_riverRunoffFlux, timeMonthly_avg_iceRunoffFlux,
+    timeMonthly_avg_rainFlux, and timeMonthly_avg_snowFlux into CMIP.wfo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    variableList = ['timeMonthly_avg_seaIceFreshWaterFlux',
+                    'timeMonthly_avg_riverRunoffFlux',
+                    'timeMonthly_avg_iceRunoffFlux',
+                    'timeMonthly_avg_rainFlux',  'timeMonthly_avg_snowFlux',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = \
+            dsIn.timeMonthly_avg_seaIceFreshWaterFlux + \
+            dsIn.timeMonthly_avg_riverRunoffFlux + \
+            dsIn.timeMonthly_avg_iceRunoffFlux + \
+            dsIn.timeMonthly_avg_rainFlux + \
+            dsIn.timeMonthly_avg_snowFlux
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/wo.py
@@ -1,0 +1,95 @@
+
+"""
+compute Sea Water Vertical Velocity, wo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+import numpy
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'wo'
+VAR_UNITS = 'm s-1'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_vertVelocityTop into CMIP.wo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_vertVelocityTop',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ds[VAR_NAME] = dsIn.timeMonthly_avg_vertVelocityTop
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+    ds = ds.rename({'nVertLevelsP1': 'olevhalf'})
+    nVertLevels = dsMesh.sizes['nVertLevels']
+    mask = cellMask3D.isel(nVertLevels=0)
+    maskSlices = [mask]
+    for zIndex in range(nVertLevels):
+        maskSlices.append(mask)
+    cellMask3D = xarray.concat(maskSlices, dim='olevhalf')
+    ds = mpas.add_mask(ds, cellMask3D)
+    ds = ds.transpose('time', 'olevhalf', 'nCells', 'nbnd')
+    ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+    ds = ds.transpose('time', 'olevhalf', 'lat', 'lon', 'nbnd')
+    depth_coord_half = numpy.zeros(nVertLevels+1)
+    depth_coord_half[1:] = dsMesh.refBottomDepth.values
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord_half',
+             'units': 'm',
+             'coord_vals': depth_coord_half},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/wo.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'wo'
 VAR_UNITS = 'm s-1'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/zhalfo.py
@@ -1,0 +1,107 @@
+
+"""
+compute 	Depth Below Geoid of Interfaces Between Ocean Layers, zhalfo
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+import numpy
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'zhalfo'
+VAR_UNITS = 'm'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_layerThickness into CMIP.zhalfo
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+
+    variableList = ['timeMonthly_avg_layerThickness',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    nVertLevels = dsMesh.sizes['nVertLevels']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        layerThickness = dsIn.timeMonthly_avg_layerThickness
+        layerThickness = layerThickness.where(cellMask3D)
+        thicknessSum = layerThickness.sum(dim='nVertLevels')
+        mask = cellMask3D.isel(nVertLevels=0)
+        zSurface = (-dsMesh.bottomDepth + thicknessSum).where(mask)
+        zSurface.compute()
+        # print('done zSurface')
+        slices = [zSurface]
+        maskSlices = [mask]
+        zLayerBot = zSurface
+        for zIndex in range(nVertLevels):
+            mask = cellMask3D.isel(nVertLevels=zIndex)
+            zLayerBot = (zLayerBot -
+                         layerThickness.isel(nVertLevels=zIndex)).where(mask)
+            zLayerBot.compute()
+            # print('done zLayerBot {}/{}'.format(zIndex+1, nVertLevels))
+            slices.append(zLayerBot)
+            maskSlices.append(mask)
+        ds[VAR_NAME] = xarray.concat(slices, dim='olevhalf')
+        mask = xarray.concat(maskSlices, dim='olevhalf')
+        ds = mpas.add_mask(ds, mask)
+        ds = ds.transpose('Time', 'olevhalf', 'nCells')
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+    depth_coord_half = numpy.zeros(nVertLevels+1)
+    depth_coord_half[1:] = dsMesh.refBottomDepth.values
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'depth_coord_half',
+             'units': 'm',
+             'coord_vals': depth_coord_half},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/zhalfo.py
@@ -16,6 +16,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'zhalfo'
 VAR_UNITS = 'm'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/cmor_handlers/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/zos.py
@@ -1,0 +1,82 @@
+
+"""
+compute Sea Surface Height Above Geoid, zos
+"""
+from __future__ import absolute_import, division, print_function
+
+import xarray
+import logging
+
+from e3sm_to_cmip import mpas
+
+# 'MPAS' as a placeholder for raw variables needed
+RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
+
+# output variable name
+VAR_NAME = 'zos'
+VAR_UNITS = 'm'
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform MPASO timeMonthly_avg_pressureAdjustedSSH into CMIP.zos
+
+    Parameters
+    ----------
+    infiles : dict
+        a dictionary with namelist, mesh and time series file names
+
+    tables : str
+        path to CMOR tables
+
+    user_input_path : str
+        path to user input json file
+
+    Returns
+    -------
+    varname : str
+        the name of the processed variable after processing is complete
+    """
+    msg = 'Starting {name}'.format(name=__name__)
+    logging.info(msg)
+
+    meshFileName = infiles['MPAS_mesh']
+    mappingFileName = infiles['MPAS_map']
+    timeSeriesFiles = infiles['MPASO']
+
+    dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
+    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    areaCell = dsMesh.areaCell.where(cellMask2D)
+
+    variableList = ['timeMonthly_avg_pressureAdjustedSSH',
+                    'xtime_startMonthly', 'xtime_endMonthly']
+
+    ds = xarray.Dataset()
+    with mpas.open_mfdataset(timeSeriesFiles, variableList) as dsIn:
+        ssh = dsIn.timeMonthly_avg_pressureAdjustedSSH.where(cellMask2D)
+        sshAvg = (ssh*areaCell).sum(dim='nCells')/areaCell.sum(dim='nCells')
+        ds[VAR_NAME] = ssh - sshAvg
+
+        ds = mpas.add_time(ds, dsIn)
+        ds.compute()
+
+    ds = mpas.remap(ds, mappingFileName)
+
+    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+
+    # create axes
+    axes = [{'table_entry': 'time',
+             'units': ds.time.units},
+            {'table_entry': 'latitude',
+             'units': 'degrees_north',
+             'coord_vals': ds.lat.values,
+             'cell_bounds': ds.lat_bnds.values},
+            {'table_entry': 'longitude',
+             'units': 'degrees_east',
+             'coord_vals': ds.lon.values,
+             'cell_bounds': ds.lon_bnds.values}]
+    try:
+        mpas.write_cmor(axes, ds, VAR_NAME, VAR_UNITS)
+    except Exception:
+        return ""
+    return VAR_NAME

--- a/e3sm_to_cmip/cmor_handlers/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/zos.py
@@ -15,6 +15,7 @@ RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 # output variable name
 VAR_NAME = 'zos'
 VAR_UNITS = 'm'
+TABLE = 'CMIP6_Omon.json'
 
 
 def handle(infiles, tables, user_input_path, **kwargs):

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -160,6 +160,25 @@ def add_mask(ds, mask):
     return ds
 
 
+def add_si_mask(ds, mask, siconc, threshold=0.05):
+    '''
+    Add a 2D mask to the data sets and apply the mask to all variabels
+    '''
+
+    mask = numpy.logical_and(
+        mask, siconc > threshold)
+
+    ds = ds.copy()
+    for varName in ds.data_vars:
+        var = ds[varName]
+        if all([dim in var.dims for dim in mask.dims]):
+            ds[varName] = var.where(mask, 0.)
+
+    ds['cellMask'] = 1.0*mask
+
+    return ds
+
+
 def get_cell_masks(dsMesh):
     '''Get 2D and 3D masks of valid MPAS cells from the mesh Dataset'''
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -1,0 +1,664 @@
+'''
+Utilities related to converting MPAS-Ocean and MPAS-Seaice files to CMOR
+'''
+
+from __future__ import absolute_import, division, print_function
+
+import re
+import numpy
+import netCDF4
+from datetime import datetime
+import sys
+import xarray
+import os
+import cmor
+import subprocess
+import tempfile
+import logging
+import argparse
+from dask.diagnostics import ProgressBar
+
+
+def remap(ds, mappingFileName, threshold=0.05):
+    '''Use ncreamp to remap the xarray Dataset to a new target grid'''
+
+    # write the dataset to a temp file
+    inFileName = _get_temp_path()
+    outFileName = _get_temp_path()
+
+    if 'depth' in ds.dims:
+        ds = ds.transpose('time', 'depth', 'nCells', 'nbnd')
+
+    write_netcdf(ds, inFileName)
+
+    # set an environment variable to make sure we're not using czender's
+    # local version of NCO instead of one we have intentionally loaded
+    env = os.environ.copy()
+    env['NCO_PATH_OVERRIDE'] = 'No'
+
+    args = ['ncremap', '-m', 'mpas', '--d2f', '-7', '--dfl_lvl=1',
+            '--no_cll_msr', '--no_frm_trm', '--no_stg_grd', '--msk_src=none',
+            '--mask_dst=none', '--map={}'.format(mappingFileName), inFileName,
+            outFileName]
+
+
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, env=env)
+    (out, err) = proc.communicate()
+    logging.info(out)
+    if(proc.returncode):
+        print(err)
+        raise subprocess.CalledProcessError('ncremap returned {}'.format(
+            proc.returncode))
+
+    ds = xarray.open_dataset(outFileName, decode_times=False,
+                             mask_and_scale=False)
+
+    if 'depth' in ds.dims:
+        ds = ds.transpose('time', 'depth', 'lat', 'lon', 'nbnd')
+
+    ds.load()
+
+    if 'cellMask' in ds:
+        mask = ds['cellMask'] > threshold
+        norm = 1./ds['cellMask'].where(mask)
+        ds = ds.drop('cellMask')
+        for varName in ds.data_vars:
+            var = ds[varName]
+            # make sure all of the mask dimensions are in the variable
+            if all([dim in var.dims for dim in mask.dims]):
+                ds[varName] = ds[varName].where(mask)*norm
+
+    # remove the temporary files
+    os.remove(inFileName)
+    os.remove(outFileName)
+
+    return ds
+
+
+def add_time(ds, dsIn, referenceDate='0001-01-01', offsetYears=0):
+    '''Parse the MPAS xtime variable into CF-compliant time'''
+
+    ds = ds.rename({'Time': 'time'})
+    dsIn = dsIn.rename({'Time': 'time'})
+    xtimeStart = dsIn.xtime_startMonthly
+    xtimeEnd = dsIn.xtime_endMonthly
+    xtimeStart = [''.join(str(xtimeStart.astype('U'))).strip()
+                  for xtimeStart in xtimeStart.values]
+
+    xtimeEnd = [''.join(str(xtimeEnd.astype('U'))).strip()
+                for xtimeEnd in xtimeEnd.values]
+
+    # fix xtimeStart, which has an offset by a time step (or so)
+    xtimeStart = ['{}_00:00:00'.format(xtime[0:10]) for xtime in xtimeStart]
+
+    daysStart = offsetYears*365 + \
+        _string_to_days_since_date(dateStrings=xtimeStart,
+                                   referenceDate=referenceDate)
+
+    daysEnd = offsetYears*365 + \
+        _string_to_days_since_date(dateStrings=xtimeEnd,
+                                   referenceDate=referenceDate)
+
+    time_bnds = numpy.zeros((len(daysStart), 2))
+    time_bnds[:, 0] = daysStart
+    time_bnds[:, 1] = daysEnd
+
+    days = 0.5*(daysStart + daysEnd)
+    ds.coords['time'] = ('time', days)
+    ds.time.attrs['units'] = 'days since {}'.format(referenceDate)
+    ds.time.attrs['bounds'] = 'time_bnds'
+
+    ds['time_bnds'] = (('time', 'nbnd'), time_bnds)
+    ds.time_bnds.attrs['units'] = 'days since {}'.format(referenceDate)
+    return ds
+
+
+def add_depth(ds, dsCoord):
+    '''Add a 1D depth coordinate to the data set'''
+    if 'nVertLevels' in ds.dims:
+        ds = ds.rename({'nVertLevels': 'depth'})
+
+        dsCoord = dsCoord.rename({'nVertLevels': 'depth'})
+        depth, depth_bnds = _compute_depth(dsCoord.refBottomDepth)
+        ds.coords['depth'] = ('depth', depth)
+        ds.depth.attrs['long_name'] = 'reference depth of the center of ' \
+                                      'each vertical level'
+        ds.depth.attrs['standard_name'] = 'depth'
+        ds.depth.attrs['units'] = 'meters'
+        ds.depth.attrs['axis'] = 'Z'
+        ds.depth.attrs['positive'] = 'down'
+        ds.depth.attrs['valid_min'] = depth_bnds[0, 0]
+        ds.depth.attrs['valid_max'] = depth_bnds[-1, 1]
+        ds.depth.attrs['bounds'] = 'depth_bnds'
+
+        ds.coords['depth_bnds'] = (('depth', 'nbnd'), depth_bnds)
+        ds.depth_bnds.attrs['long_name'] = 'Gridcell depth interfaces'
+
+        for varName in ds.data_vars:
+            var = ds[varName]
+            if 'depth' in var.dims:
+                var = var.assign_coords(depth=ds.depth)
+                ds[varName] = var
+
+    return ds
+
+
+def add_mask(ds, mask):
+    '''
+    Add a 2D or 3D mask to the data sets and multiply all variables by the
+    mask
+    '''
+    ds = ds.copy()
+    for varName in ds.data_vars:
+        var = ds[varName]
+        if all([dim in var.dims for dim in mask.dims]):
+            ds[varName] = var.where(mask, 0.)
+
+    ds['cellMask'] = 1.0*mask
+
+    return ds
+
+
+def get_cell_masks(dsMesh):
+    '''Get 2D and 3D masks of valid MPAS cells from the mesh Dataset'''
+
+    cellMask2D = dsMesh.maxLevelCell > 0
+
+    nVertLevels = dsMesh.sizes['nVertLevels']
+
+    vertIndex = \
+        xarray.DataArray.from_dict({'dims': ('nVertLevels',),
+                                    'data': numpy.arange(nVertLevels)})
+
+    cellMask3D = vertIndex < dsMesh.maxLevelCell
+
+    return cellMask2D, cellMask3D
+
+
+def get_sea_floor_values(ds, dsMesh):
+    '''Sample fields in the data set at the sea floor'''
+
+    ds = ds.copy()
+    cellMask2D = dsMesh.maxLevelCell > 0
+    nVertLevels = dsMesh.sizes['nVertLevels']
+
+    # zero-based indexing in python
+    maxLevelCell = dsMesh.maxLevelCell - 1
+
+    vertIndex = \
+        xarray.DataArray.from_dict({'dims': ('nVertLevels',),
+                                    'data': numpy.arange(nVertLevels)})
+
+    for varName in ds.data_vars:
+        if 'nVertLevels' not in ds[varName].dims or \
+                'nCells' not in ds[varName].dims:
+            continue
+
+        # mask only the values with the right vertical index
+        ds[varName] = ds[varName].where(maxLevelCell == vertIndex)
+
+        # Each vertical layer has at most one non-NaN value so the "sum"
+        # over the vertical is used to collapse the array in the vertical
+        # dimension
+        ds[varName] = ds[varName].sum(dim='nVertLevels').where(cellMask2D)
+
+    return ds
+
+
+def open_mfdataset(fileNames, variableList=None,
+                   chunks={'nCells': 32768, 'Time': 6}):
+    '''Open a multi-file xarray Dataset, retaining only the listed variables'''
+
+    ds = xarray.open_mfdataset(fileNames, concat_dim='Time',
+                               mask_and_scale=False, chunks=chunks)
+
+    if variableList is not None:
+        allvars = ds.data_vars.keys()
+
+        # get set of variables to drop (all ds variables not in vlist)
+        dropvars = set(allvars) - set(variableList)
+
+        # drop spurious variables
+        ds = ds.drop(dropvars)
+
+        # must also drop all coordinates that are not associated with the
+        # variables
+        coords = set()
+        for avar in ds.data_vars.keys():
+            coords |= set(ds[avar].coords.keys())
+        dropcoords = set(ds.coords.keys()) - coords
+
+        # drop spurious coordinates
+        ds = ds.drop(dropcoords)
+
+    return ds
+
+
+def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals):
+    '''Write an xarray Dataset with NetCDF4 fill values where needed'''
+    encodingDict = {}
+    variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
+    for variableName in variableNames:
+        isNumeric = numpy.issubdtype(ds[variableName].dtype, numpy.number)
+        if isNumeric and numpy.any(numpy.isnan(ds[variableName])):
+            dtype = ds[variableName].dtype
+            for fillType in fillValues:
+                if dtype == numpy.dtype(fillType):
+                    encodingDict[variableName] = \
+                        {'_FillValue': fillValues[fillType]}
+                    break
+        else:
+            encodingDict[variableName] = {'_FillValue': None}
+
+    update_history(ds)
+
+    ds.to_netcdf(fileName, encoding=encodingDict)
+
+
+def update_history(ds):
+    '''Add or append history to attributes of a data set'''
+
+    thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + \
+        " ".join(sys.argv[:])
+    if 'history' in ds.attrs:
+        newhist = '\n'.join([thiscommand, ds.attrs['history']])
+    else:
+        newhist = thiscommand
+    ds.attrs['history'] = newhist
+
+
+def convert_namelist_to_dict(fileName):
+    '''Convert an MPAS namelist file to a python dictionary'''
+    nml = {}
+
+    regex = re.compile(r"^\s*(.*?)\s*=\s*['\"]*(.*?)['\"]*\s*\n")
+    with open(fileName) as f:
+        for line in f:
+            match = regex.findall(line)
+            if len(match) > 0:
+                nml[match[0][0].lower()] = match[0][1]
+    return nml
+
+
+def setup_cmor(varname, tables, user_input_path, component='ocean'):
+    '''Set up CMOR for MPAS-Ocean or MPAS-Seaice'''
+    logfile = os.path.join(os.getcwd(), 'logs')
+    if not os.path.exists(logfile):
+        os.makedirs(logfile)
+    logfile = os.path.join(logfile, varname + '.log')
+    cmor.setup(
+        inpath=tables,
+        netcdf_file_action=cmor.CMOR_REPLACE,
+        logfile=logfile)
+    cmor.dataset_json(str(user_input_path))
+    if component == 'ocean':
+        table = 'CMIP6_Omon.json'
+    elif component == 'seaice':
+        table = 'CMIP6_SImon.json'
+    else:
+        raise ValueError('Unexpected component {}'.format(component))
+    try:
+        cmor.load_table(table)
+    except Exception:
+        raise ValueError('Unable to load table from {}'.format(varname))
+
+
+def write_cmor(axes, ds, varname, varunits, **kwargs):
+    '''Write a time series of a variable in the format expected by CMOR'''
+    axis_ids = list()
+    for axis in axes:
+        axis_id = cmor.axis(**axis)
+        axis_ids.append(axis_id)
+
+    fillValue = 1e20
+    if numpy.any(numpy.isnan(ds[varname])):
+        mask = numpy.isfinite(ds[varname])
+        ds[varname] = ds[varname].where(mask, fillValue)
+
+    # create the cmor variable
+    varid = cmor.variable(str(varname), str(varunits), axis_ids,
+                          missing_value=fillValue, **kwargs)
+
+    # write out the data
+    try:
+        cmor.write(
+            varid,
+            ds[varname].values,
+            time_vals=ds.time.values,
+            time_bnds=ds.time_bnds.values)
+    except Exception as error:
+        logging.exception('Error in cmor.write for {}'.format(varname))
+        raise
+    finally:
+        cmor.close(varid)
+
+
+def compute_moc_streamfunction(dsIn=None, dsMesh=None, dsMasks=None,
+                               showProgress=True):
+    '''
+    An entry point to compute the MOC streamfunction (including Bolus velocity)
+    and write it to a new file.
+    '''
+
+    useCommandLine = dsIn is None and dsMesh is None and dsMasks is None
+
+    if useCommandLine:
+        # must be running from the command line
+
+        parser = argparse.ArgumentParser(
+            description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+        parser.add_argument("-m", "--meshFileName", dest="meshFileName",
+                            type=str, required=True,
+                            help="An MPAS file with mesh data (edgesOnCell, "
+                                 "etc.)")
+        parser.add_argument("-r", "--regionMasksFileName",
+                            dest="regionMasksFileName", type=str,
+                            required=True,
+                            help="An MPAS file with MOC region masks")
+        parser.add_argument("-i", "--inFileNames", dest="inFileNames",
+                            type=str, required=True,
+                            help="An MPAS monthly mean files from which to "
+                                 "compute transport.")
+        parser.add_argument("-o", "--outFileName", dest="outFileName",
+                            type=str, required=True,
+                            help="An output MPAS file with transport time "
+                                 "series")
+        args = parser.parse_args()
+
+        dsMesh = xarray.open_dataset(args.meshFileName)
+        dsMesh = dsMesh.isel(Time=0, drop=True)
+
+        dsMasks = xarray.open_dataset(args.regionMasksFileName)
+
+        variableList = ['timeMonthly_avg_normalVelocity',
+                        'timeMonthly_avg_normalGMBolusVelocity',
+                        'timeMonthly_avg_vertVelocityTop',
+                        'timeMonthly_avg_vertGMBolusVelocityTop',
+                        'timeMonthly_avg_layerThickness',
+                        'xtime_startMonthly', 'xtime_endMonthly']
+
+        dsIn = open_mfdataset(args.inFileNames, variableList)
+
+    dsOut = xarray.Dataset()
+
+    dsIn = dsIn.chunk(chunks={'nCells': None, 'nVertLevels': None,
+                              'Time': 6})
+
+    cellsOnEdge = dsMesh.cellsOnEdge - 1
+
+    totalNormalVelocity = \
+        (dsIn.timeMonthly_avg_normalVelocity +
+         dsIn.timeMonthly_avg_normalGMBolusVelocity)
+    layerThickness = dsIn.timeMonthly_avg_layerThickness
+
+    layerThicknessEdge = 0.5*(layerThickness[:, cellsOnEdge[:, 0], :] +
+                              layerThickness[:, cellsOnEdge[:, 1], :])
+
+    totalVertVelocityTop = \
+        (dsIn.timeMonthly_avg_vertVelocityTop +
+         dsIn.timeMonthly_avg_vertGMBolusVelocityTop)
+
+    moc, coords = _compute_moc_time_series(totalNormalVelocity,
+                                           totalVertVelocityTop,
+                                           layerThicknessEdge, dsMesh,
+                                           dsMasks, showProgress)
+    dsOut['moc'] = moc
+    dsOut = dsOut.assign_coords(**coords)
+
+    dsOut = add_time(dsOut, dsIn)
+
+    if useCommandLine:
+        dsOut = dsOut.chunk({'lat': None, 'depth': None, 'time': 1,
+                             'basin': 1})
+
+        for attrName in dsIn.attrs:
+            dsOut.attrs[attrName] = dsIn.attrs[attrName]
+
+        time = datetime.now().strftime('%c')
+
+        history = '{}: {}'.format(time, ' '.join(sys.argv))
+
+        if 'history' in dsOut.attrs:
+            dsOut.attrs['history'] = '{}\n{}'.format(history,
+                                                     dsOut.attrs['history'])
+        else:
+            dsOut.attrs['history'] = history
+
+        write_netcdf(dsOut, args.outFileName)
+    else:
+        return dsOut
+
+
+def _string_to_days_since_date(dateStrings, referenceDate='0001-01-01'):
+    """
+    Turn an array-like of date strings into the number of days since the
+    reference date
+
+    """
+
+    dates = [_string_to_datetime(string) for string in dateStrings]
+    days = _datetime_to_days(dates, referenceDate=referenceDate)
+
+    days = numpy.array(days)
+    return days
+
+
+def _string_to_datetime(dateString):
+    """ Given a date string and a calendar, returns a datetime.datetime"""
+
+    (year, month, day, hour, minute, second) = \
+        _parse_date_string(dateString)
+
+    return datetime(year=year, month=month, day=day, hour=hour,
+                    minute=minute, second=second)
+
+
+def _parse_date_string(dateString):
+    """
+    Given a string containing a date, returns a tuple defining a date of the
+    form (year, month, day, hour, minute, second) appropriate for constructing
+    a datetime or timedelta
+    """
+
+    # change underscores to spaces so both can be supported
+    dateString = dateString.replace('_', ' ').strip()
+    if ' ' in dateString:
+        ymd, hms = dateString.split(' ')
+    else:
+        if '-' in dateString:
+            ymd = dateString
+            # error can result if dateString = '1990-01'
+            # assume this means '1990-01-01'
+            if len(ymd.split('-')) == 2:
+                ymd += '-01'
+            hms = '00:00:00'
+        else:
+            ymd = '0001-01-01'
+            hms = dateString
+
+    if '.' in hms:
+        hms = hms.replace('.', ':')
+
+    if '-' in ymd:
+        (year, month, day) \
+            = [int(sub) for sub in ymd.split('-')]
+    else:
+        day = int(ymd)
+        year = 0
+        month = 1
+
+    if ':' in hms:
+        (hour, minute, second) \
+            = [int(sub) for sub in hms.split(':')]
+    else:
+        second = int(hms)
+        minute = 0
+        hour = 0
+    return (year, month, day, hour, minute, second)
+
+
+def _datetime_to_days(dates, referenceDate='0001-01-01'):
+    """
+    Given dates and a reference date, returns the days since
+    the reference date as an array of floats.
+    """
+
+    days = netCDF4.date2num(dates, 'days since {}'.format(referenceDate),
+                            calendar='noleap')
+
+    return days
+
+
+def _compute_depth(refBottomDepth):
+    """
+    Computes depth and depth bounds given refBottomDepth
+
+    Parameters
+    ----------
+    refBottomDepth : ``xarray.DataArray``
+        the depth of the bottom of each vertical layer in the initial state
+        (perfect z-level coordinate)
+
+    Returns
+    -------
+    depth : ``xarray.DataArray``
+        the vertical coordinate defining the middle of each layer
+    depth_bnds : ``xarray.DataArray``
+        the vertical coordinate defining the top and bottom of each layer
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    refBottomDepth = refBottomDepth.values
+
+    depth_bnds = numpy.zeros((len(refBottomDepth), 2))
+
+    depth_bnds[0, 0] = 0.
+    depth_bnds[1:, 0] = refBottomDepth[0:-1]
+    depth_bnds[:, 1] = refBottomDepth
+    depth = 0.5*(depth_bnds[:, 0] + depth_bnds[:, 1])
+
+    return depth, depth_bnds
+
+
+def _compute_moc_time_series(normalVelocity, vertVelocityTop,
+                             layerThicknessEdge, dsMesh, dsMasks,
+                             showProgress):
+    '''compute MOC time series as a post-process'''
+
+    dvEdge = dsMesh.dvEdge
+    areaCell = dsMesh.areaCell
+    latCell = numpy.rad2deg(dsMesh.latCell)
+    nTime = normalVelocity.sizes['Time']
+    nCells = dsMesh.sizes['nCells']
+    nVertLevels = dsMesh.sizes['nVertLevels']
+
+    nRegions = 1 + dsMasks.sizes['nRegions']
+
+    regionNames = ['Global'] + [str(name.values) for name in
+                                dsMasks.regionNames]
+
+    latBinSize = 1.0
+
+    lat = numpy.arange(-90., 90. + latBinSize, latBinSize)
+    lat_bnds = numpy.zeros((len(lat)-1, 2))
+    lat_bnds[:, 0] = lat[0:-1]
+    lat_bnds[:, 1] = lat[1:]
+    lat = 0.5*(lat_bnds[:, 0] + lat_bnds[:, 1])
+
+    lat_bnds = xarray.DataArray(lat_bnds, dims=('lat', 'nbnd'))
+    lat = xarray.DataArray(lat, dims=('lat',))
+
+    depth, depth_bnds = _compute_depth(dsMesh.refBottomDepth)
+
+    depth_bnds = xarray.DataArray(depth_bnds, dims=('depth', 'nbnd'))
+    depth = xarray.DataArray(depth, dims=('depth',))
+
+    transport = {}
+    transport['Global'] = xarray.DataArray(numpy.zeros((nTime, nVertLevels)),
+                                           dims=('Time', 'nVertLevels',))
+
+    cellMasks = {}
+    cellMasks['Global'] = xarray.DataArray(numpy.ones(nCells),
+                                           dims=('nCells',))
+
+    for regionIndex in range(1, nRegions):
+        regionName = regionNames[regionIndex]
+        dsMask = dsMasks.isel(nTransects=regionIndex-1, nRegions=regionIndex-1)
+        edgeIndices = dsMask.transectEdgeGlobalIDs
+        mask = edgeIndices > 0
+        edgeIndices = edgeIndices[mask] - 1
+        edgeSigns = dsMask.transectEdgeMaskSigns[edgeIndices]
+        v = normalVelocity[:, edgeIndices, :]
+        h = layerThicknessEdge[:, edgeIndices, :]
+        dv = dvEdge[edgeIndices]
+        transport[regionName] = (v*h*dv*edgeSigns).sum(
+            dim='maxEdgesInTransect')
+
+        _compute_dask(transport[regionName], showProgress,
+                      'Computing transport through southern boundary of '
+                      '{}'.format(regionName))
+
+        cellMasks[regionName] = dsMask.regionCellMasks
+        cellMasks[regionName].compute()
+
+    mocs = {}
+
+    for regionName in regionNames:
+        mocSlice = numpy.zeros((nTime, nVertLevels+1))
+        mocSlice[:, 1:] = transport[regionName].cumsum(
+            dim='nVertLevels').values
+
+        mocSlice = xarray.DataArray(mocSlice,
+                                    dims=('Time', 'nVertLevelsP1'))
+        mocSlices = [mocSlice]
+        binCounts = []
+        for iLat in range(lat_bnds.sizes['lat']):
+            mask = numpy.logical_and(numpy.logical_and(
+                cellMasks[regionName] == 1, latCell >= lat_bnds[iLat, 0]),
+                latCell < lat_bnds[iLat, 1])
+            binCounts.append(numpy.count_nonzero(mask))
+            mocTop = mocSlices[iLat] + (vertVelocityTop[:, mask, :] *
+                                        areaCell[mask]).sum(dim='nCells')
+            mocSlices.append(mocTop)
+
+        moc = xarray.concat(mocSlices, dim='lat')
+        moc = moc.transpose('Time', 'nVertLevelsP1', 'lat')
+        # average to bin and level centers
+        moc = 0.25*(moc[:, 0:-1, 0:-1] + moc[:, 0:-1, 1:] +
+                    moc[:, 1:, 0:-1] + moc[:, 1:, 1:])
+        moc = moc.rename({'nVertLevelsP1': 'depth'})
+        binCounts = xarray.DataArray(binCounts, dims=('lat'))
+        moc = moc.where(binCounts > 0)
+
+        _compute_dask(moc, showProgress, 'Computing {} MOC'.format(regionName))
+
+        mocs[regionName] = moc
+
+    mocs = xarray.concat(mocs.values(), dim='basin')
+    mocs = mocs.transpose('Time', 'basin', 'depth', 'lat')
+
+    regionNames = xarray.DataArray(regionNames, dims=('basin',))
+
+    coords = dict(lat=lat, lat_bnds=lat_bnds, depth=depth,
+                  depth_bnds=depth_bnds, regionNames=regionNames)
+
+    return mocs, coords
+
+
+def _compute_dask(ds, showProgress, message):
+
+    if showProgress:
+        print(message)
+        with ProgressBar():
+            ds.compute()
+    else:
+        ds.compute()
+
+
+def _get_temp_path():
+    '''Returns the name of a temporary NetCDF file'''
+    return '{}/{}.nc'.format(tempfile.gettempdir(),
+                             next(tempfile._get_candidate_names()))


### PR DESCRIPTION
Also adds functionality needed for sea-ice handlers to the `mpas` module:
* masking based on the sea-ice concentration
* area-weighted interpolation from vertices to cell centers (to put velocities at cell centers)

closes #12 