### PR TITLE
Fix fill value

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -330,7 +330,7 @@ def write_cmor(axes, ds, varname, varunits, **kwargs):
         axis_id = cmor.axis(**axis)
         axis_ids.append(axis_id)
 
-    fillValue = 1e20
+    fillValue = netCDF4.default_fillvals['f4']
     if numpy.any(numpy.isnan(ds[varname])):
         mask = numpy.isfinite(ds[varname])
         ds[varname] = ds[varname].where(mask, fillValue)


### PR DESCRIPTION
Use the standard NetCDF4 fill value, not the cmor default of 1e20, which is too close to reasonable ocean values for certain fields.