### PR TITLE
After remap, use xarray masking

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -54,8 +54,7 @@ def remap(ds, mappingFileName, threshold=0.05):
         raise subprocess.CalledProcessError(
             'ncremap returned {}'.format(proc.returncode))
 
-    ds = xarray.open_dataset(outFileName, decode_times=False,
-                             mask_and_scale=False)
+    ds = xarray.open_dataset(outFileName, decode_times=False)
 
     if 'depth' in ds.dims:
         ds = ds.transpose('time', 'depth', 'lat', 'lon', 'nbnd')


### PR DESCRIPTION
This replaces fill values with NaNs, which is the behavior we want for subsequent masking.

This should fix the sea-ice masking issue we've been seeing.