### PR TITLE
Make conda recipe noarch: python

### DIFF
--- a/conda/conda_build.sh
+++ b/conda/conda_build.sh
@@ -1,5 +1,5 @@
 export VERSION="1.7.0"
-export BUILD_NAME="1"
+export BUILD_NAME="2"
 export CONDA_BLD_PATH=~/conda-bld
 PLATFORM="linux-64"
 PKG="e3sm_to_cmip"
@@ -26,7 +26,7 @@ if [ $? -eq 1 ]; then
 fi
 
 if [ ! -z "$1" ]; then
-    anaconda upload -u e3sm -l "$1" $CONDA_BLD_PATH/$PLATFORM/$PKG-$VERSION-$BUILD_NAME.tar.bz2 
+    anaconda upload -u e3sm -l "$1" $CONDA_BLD_PATH/$PLATFORM/$PKG-$VERSION-$BUILD_NAME.tar.bz2
 else
     anaconda upload -u e3sm $CONDA_BLD_PATH/$PLATFORM/$PKG-$VERSION-$BUILD_NAME.tar.bz2
 fi

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,6 +10,7 @@ source:
 build:
   script: python setup.py install
   string: {{ environ['BUILD_NAME'] }}
+  noarch: python
 
 about:
   home: https://github.com/E3SM-Project/e3sm_to_cmip
@@ -19,17 +20,17 @@ about:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - setuptools
 
   run:
-      - python >=3.7
-      - nco
-      - cmor >=3.6.0
-      - tqdm
-      - pyyaml
-      - xarray
-      - netcdf4
-      - dask
-      - scipy
+    - python >=3.7
+    - nco
+    - cmor >=3.6.0
+    - tqdm
+    - pyyaml
+    - xarray
+    - netcdf4
+    - dask
+    - scipy


### PR DESCRIPTION
There is no need for separate builds for different python versions and E3SM-Unified is now using python 3.8 by default, and supports python 3.7-3.9.

Bumped the build number to 2.
