### PR TITLE
Add cdutil, cdms2, cwl, and nodejs to dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,7 @@ Once you have dev environment setup, simply run:
 python setup.py install
 ```
 
-### NOTE
-
-Two handlers (pfull and phalf) require the addition of the "cdms2" and "cdutil" packages. These packages arent included in the default dependency list since the two handlers aren't widely used. If you require these two variables, add "cdms2" and "cdutil" to the package list at install time.
-
-
-
-### Example
+## Example
 
 Here's an example of the tool usage, with the variables tas, prc, and rlut. The time-series files containing the regridded output are in a directory named input_path, and a directory named output_path will be used to hold the CMIP6 output.
 

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -6,14 +6,22 @@ channels:
 dependencies:
   # Base
   # ==================
-  - python=3.9.6
-  - pip=21.2.2
-  - nco=5.0.1
-  - cmor >=3.6.0
+  - python=3.8.10
+  - pip=21.2.4
+  - nco=4.9.9
+  - cmor=3.6.1
   - tqdm=4.62.0
   - pyyaml=5.4.1
   - xarray=0.19.0
   - netcdf4=1.5.6
   - dask=2021.7.2
   - scipy=1.7.0
+  # Used for phalf and pfull handlers.
+  # Note, these two packages don't support Python >3.8
+  - cdms2=3.1.5
+  - cdutil=8.2.1
+    # CWL
+  # ==================
+  - cwltool=3.1.20210816212154
+  - nodejs=16.6.1
 prefix: /opt/miniconda3/envs/e3sm_to_cmip_dev


### PR DESCRIPTION
- Closes #79 

This PR adds the remaining development environment dependencies, including:
- `cdutil`
- `cdms2`,
- `cwl`
- `nodejs`

