### PR TITLE
attempt to fix highfreq issue

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/pr_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/pr_highfreq.py
@@ -1,0 +1,58 @@
+"""
+PRECT to pr converter for daily atmos data
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import cmor
+from e3sm_to_cmip.lib import handle_variables
+
+# list of raw variable names needed
+RAW_VARIABLES = [str('PRECT')]
+VAR_NAME = str('pr')
+VAR_UNITS = str('kg m-2 s-1')
+TABLE = str('CMIP6_day.json')
+
+
+def write_data(varid, data, timeval, timebnds, index, **kwargs):
+    """
+    pr = PRECT * 1000.0
+    """
+    outdata = data['PRECT'].values[index, :] * 1000.0
+    if kwargs.get('simple'):
+        return outdata
+    cmor.write(
+        varid,
+        outdata,
+        time_vals=timeval,
+        time_bnds=timebnds)
+# ------------------------------------------------------------------
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform E3SM.TS into CMIP.ts
+    Parameters
+    ----------
+        infiles (List): a list of strings of file names for the raw input data
+        tables (str): path to CMOR tables
+        user_input_path (str): path to user input json file
+    Returns
+    -------
+        var name (str): the name of the processed variable after processing is complete
+    """
+
+    return handle_variables(
+        metadata_path=user_input_path,
+        tables=tables,
+        table=kwargs.get('table', TABLE),
+        infiles=infiles,
+        raw_variables=RAW_VARIABLES,
+        write_data=write_data,
+        outvar_name=VAR_NAME,
+        outvar_units=VAR_UNITS,
+        serial=kwargs.get('serial'),
+        logdir=kwargs.get('logdir'),
+        simple=kwargs.get('simple'),
+        outpath=kwargs.get('outpath'))
+# ------------------------------------------------------------------

--- a/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
@@ -1,0 +1,54 @@
+"""
+FLUT to rlut_highfreq converter
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import cmor
+from e3sm_to_cmip.lib import handle_variables
+
+# list of raw variable names needed
+RAW_VARIABLES = [str('FLUT')]
+VAR_NAME = str('rlut')
+VAR_UNITS = str('W m-2')
+TABLE = str('CMIP6_day.json')
+POSITIVE = str('up')
+
+def write_data(varid, data, timeval, timebnds, **kwargs):
+    outdata = data["FLUT"].values
+    if kwargs.get('simple'):
+        return outdata
+    cmor.write(
+        varid,
+        outdata,
+        time_vals=timeval,
+        time_bnds=timebnds)
+# ------------------------------------------------------------------
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform E3SM.TS into CMIP.ts
+    Parameters
+    ----------
+        infiles (List): a list of strings of file names for the raw input data
+        tables (str): path to CMOR tables
+        user_input_path (str): path to user input json file
+    Returns
+    -------
+        var name (str): the name of the processed variable after processing is complete
+    """
+    return handle_variables(
+        metadata_path=user_input_path,
+        tables=tables,
+        table=kwargs.get('table', TABLE),
+        infiles=infiles,
+        raw_variables=RAW_VARIABLES,
+        write_data=write_data,
+        outvar_name=VAR_NAME,
+        outvar_units=VAR_UNITS,
+        serial=kwargs.get('serial'),
+        positive=POSITIVE,
+        logdir=kwargs.get('logdir'),
+        simple=kwargs.get('simple'),
+        outpath=kwargs.get('outpath'))
+# ------------------------------------------------------------------

--- a/e3sm_to_cmip/resources/default_handler_info.yaml
+++ b/e3sm_to_cmip/resources/default_handler_info.yaml
@@ -7,7 +7,7 @@
   e3sm_name: AODVIS
   units: '1'
   table: CMIP6_AERmon.json
-  
+
 - cmip_name: cltisccp
   e3sm_name: CLDTOT_ISCCP
   units: "%"
@@ -293,20 +293,8 @@
   units: K
   table: CMIP6_day.json
 
-- cmip_name: rlut_highfreq
-  e3sm_name: FLUT
-  units: "W m-2"
-  table: CMIP6_Aday.json
-  positive: up
-
 - cmip_name: rsut
   e3sm_name: FSUTOA
   units: "W m-2"
   table: CMIP6_Amon.json
   positive: up
-
-- cmip_name: pr_highfreq
-  e3sm_name: PRECT
-  units: 'kg m-2 s-1'
-  table: CMIP6_day.json
-  unit_conversion: 'm/s-to-kg/ms'

--- a/scripts/cwl_workflows/atm-highfreq/atm-highfreq.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/atm-highfreq.cwl
@@ -53,8 +53,6 @@ steps:
     run: discover_atm_files.cwl
     in:
       input: data_path
-      start: step_find_start_end/start_year
-      end: step_find_start_end/end_year
     out:
       - atm_files
   

--- a/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
@@ -12,15 +12,6 @@ requirements:
           import re
           import argparse
 
-          def get_year(filepath):
-              # Works for files matching the pattern: "somelongcasename.cam.h0.1850-12.nc"
-              _, name = os.path.split(filepath)
-              pattern = r'[c|e]am\.h\d'
-              s = re.search(pattern, name)
-              if not s:
-                raise ValueError(f"Unable to find year for file {name}")
-              return int(name[s.end() + 1: s.end() + 5])
-
           def main():
               parser = argparse.ArgumentParser()
               parser.add_argument(
@@ -39,16 +30,16 @@ requirements:
               start = _args.start_year
               end = _args.end_year
 
-              atm_pattern = f'[c|e]am\.h\d'
+              atm_pattern = r'[c|e]am\.h\d'
               atm_files = list()
 
-              for root, _, files in os.walk(inpath):
-                  if files:
-                      for f in files:
-                          if re.search(atm_pattern, f):
-                              year = get_year(f)
-                              if year >= start and year <= end:
-                                  atm_files.append(os.path.join(root, f))
+              for root, dirs, files in os.walk(inpath):
+                  if not files or dirs:
+                      continue
+
+                  for f in files:
+                      if re.search(atm_pattern, f):
+                          atm_files.append(os.path.join(root, f))
 
               for f in sorted(atm_files):
                   print(f)
@@ -64,14 +55,6 @@ inputs:
     type: string
     inputBinding:
       prefix: --input
-  start:
-    type: int
-    inputBinding:
-      prefix: --start
-  end:
-    type: int
-    inputBinding:
-      prefix: --end
 
 outputs:
   atm_files:

--- a/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
@@ -21,7 +21,7 @@ requirements:
               parser.add_argument(
                   '-e', '--end-year', help="end year", type=int)
               _args = parser.parse_args(sys.argv[1:])
-              
+
               inpath = _args.input
               if not os.path.exists(inpath):
                   print("ERROR: directory not found {}".format(inpath), file=sys.stderr)
@@ -34,18 +34,15 @@ requirements:
               atm_files = list()
 
               for root, dirs, files in os.walk(inpath):
-                  if not files or dirs:
-                      continue
-
-                  for f in files:
-                      if re.search(atm_pattern, f):
-                          atm_files.append(os.path.join(root, f))
+                for f in files:
+                  if re.search(atm_pattern, f):
+                    atm_files.append(os.path.join(root, f))
 
               for f in sorted(atm_files):
                   print(f)
 
               return 0
-              
+
           if __name__ == "__main__":
               sys.exit(main())
 


### PR DESCRIPTION
I _think_ this will fix the issue with the high frequency time gaps, however since I dont have access to any data I havent been able to test it. There's a 10 year chunk of testing data setup under `/p/user_pub/e3sm/baldwin32/warehouse_testing/E3SM/test/test/test/atmos/native/model-output/day/ens1/v0/` to test this change, create a new directory, and paste this into a file named atm-highfreq-job.yaml

```
# path to the raw model data
data_path: /p/user_pub/e3sm/baldwin32/warehouse_testing/E3SM/test/test/test/atmos/native/model-output/day/ens1/v0/

# size of output data files in years
frequency: 2

# the sampling frequency of the data itself
sample_freq: day

# the number of time steps per day
time_steps_per_day: '1'

# number of ncremap workers
num_workers: 12

# slurm account info
account: e3sm
partition: debug
timeout: 2:00:00

# horizontal regridding file path
hrz_atm_map_path: /home/zender1/data/maps/map_ne30np4_to_cmip6_180x360_aave.20181001.nc

# path to CMIP6 tables directory
tables_path: /home/baldwin32/projects/cmip6-cmor-tables/Tables/

# path to CMOR case metadata
metadata_path: /p/user_pub/e3sm/baldwin32/resources/CMIP6-Metadata/E3SM-1-0/piControl_r1i1p1f1.json 

# list if E3SM raw variable names
std_var_list: [PRECT]

# list of CMIP6 variable names
std_cmor_list: [pr_highfreq]
```

Then, from that directory run `cwltool <path_to_your_e3sm_to_cmip_directory>/scripts/cwl_workflows/atm-highfreq/atm-highfreq.cwl atm-highfreq-job.yaml`

When the job (hopefully) exits successfully, look under the CMIP6 directory tree for the only leaf directory. It should contain 5 netCDF files, where the time stamps dont have any gaps in them (i.e. the first one should end on 0002-12-31 and the next one should start at 0003-01-01). All of these instructions are from memory, so its possible that the paths might not be perfect, please check them before running it.