### PR TITLE
PR #83 Fix high freq cwl (review fixes)

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/pr_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/pr_highfreq.py
@@ -1,0 +1,58 @@
+"""
+PRECT to pr converter for daily atmos data
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import cmor
+from e3sm_to_cmip.lib import handle_variables
+
+# list of raw variable names needed
+RAW_VARIABLES = [str('PRECT')]
+VAR_NAME = str('pr')
+VAR_UNITS = str('kg m-2 s-1')
+TABLE = str('CMIP6_day.json')
+
+
+def write_data(varid, data, timeval, timebnds, index, **kwargs):
+    """
+    pr = PRECT * 1000.0
+    """
+    outdata = data['PRECT'].values[index, :] * 1000.0
+    if kwargs.get('simple'):
+        return outdata
+    cmor.write(
+        varid,
+        outdata,
+        time_vals=timeval,
+        time_bnds=timebnds)
+# ------------------------------------------------------------------
+
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform E3SM.TS into CMIP.ts
+    Parameters
+    ----------
+        infiles (List): a list of strings of file names for the raw input data
+        tables (str): path to CMOR tables
+        user_input_path (str): path to user input json file
+    Returns
+    -------
+        var name (str): the name of the processed variable after processing is complete
+    """
+
+    return handle_variables(
+        metadata_path=user_input_path,
+        tables=tables,
+        table=kwargs.get('table', TABLE),
+        infiles=infiles,
+        raw_variables=RAW_VARIABLES,
+        write_data=write_data,
+        outvar_name=VAR_NAME,
+        outvar_units=VAR_UNITS,
+        serial=kwargs.get('serial'),
+        logdir=kwargs.get('logdir'),
+        simple=kwargs.get('simple'),
+        outpath=kwargs.get('outpath'))
+# ------------------------------------------------------------------

--- a/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
@@ -14,12 +14,13 @@ VAR_UNITS = str('W m-2')
 TABLE = str('CMIP6_day.json')
 POSITIVE = str('up')
 
-def write_data(varid, data, timeval, timebnds, index, **kwargs):
+def write_data(varid, data, timeval, timebnds, **kwargs):
+    outdata = data["FLUT"].values
     if kwargs.get('simple'):
-        return data
+        return outdata
     cmor.write(
         varid,
-        data,
+        outdata,
         time_vals=timeval,
         time_bnds=timebnds)
 # ------------------------------------------------------------------

--- a/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
@@ -1,0 +1,53 @@
+"""
+FLUT to rlut_highfreq converter
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import cmor
+from e3sm_to_cmip.lib import handle_variables
+
+# list of raw variable names needed
+RAW_VARIABLES = [str('FLUT')]
+VAR_NAME = str('rlut')
+VAR_UNITS = str('W m-2')
+TABLE = str('CMIP6_day.json')
+POSITIVE = str('up')
+
+def write_data(varid, data, timeval, timebnds, index, **kwargs):
+    if kwargs.get('simple'):
+        return data
+    cmor.write(
+        varid,
+        data,
+        time_vals=timeval,
+        time_bnds=timebnds)
+# ------------------------------------------------------------------
+
+def handle(infiles, tables, user_input_path, **kwargs):
+    """
+    Transform E3SM.TS into CMIP.ts
+    Parameters
+    ----------
+        infiles (List): a list of strings of file names for the raw input data
+        tables (str): path to CMOR tables
+        user_input_path (str): path to user input json file
+    Returns
+    -------
+        var name (str): the name of the processed variable after processing is complete
+    """
+    return handle_variables(
+        metadata_path=user_input_path,
+        tables=tables,
+        table=kwargs.get('table', TABLE),
+        infiles=infiles,
+        raw_variables=RAW_VARIABLES,
+        write_data=write_data,
+        outvar_name=VAR_NAME,
+        outvar_units=VAR_UNITS,
+        serial=kwargs.get('serial'),
+        positive=POSITIVE,
+        logdir=kwargs.get('logdir'),
+        simple=kwargs.get('simple'),
+        outpath=kwargs.get('outpath'))
+# ------------------------------------------------------------------

--- a/e3sm_to_cmip/resources/default_handler_info.yaml
+++ b/e3sm_to_cmip/resources/default_handler_info.yaml
@@ -293,12 +293,6 @@
   units: K
   table: CMIP6_day.json
 
-- cmip_name: rlut_highfreq
-  e3sm_name: FLUT
-  units: "W m-2"
-  table: CMIP6_Aday.json
-  positive: up
-
 - cmip_name: rsut
   e3sm_name: FSUTOA
   units: "W m-2"

--- a/e3sm_to_cmip/resources/default_handler_info.yaml
+++ b/e3sm_to_cmip/resources/default_handler_info.yaml
@@ -7,7 +7,7 @@
   e3sm_name: AODVIS
   units: '1'
   table: CMIP6_AERmon.json
-  
+
 - cmip_name: cltisccp
   e3sm_name: CLDTOT_ISCCP
   units: "%"
@@ -304,9 +304,3 @@
   units: "W m-2"
   table: CMIP6_Amon.json
   positive: up
-
-- cmip_name: pr_highfreq
-  e3sm_name: PRECT
-  units: 'kg m-2 s-1'
-  table: CMIP6_day.json
-  unit_conversion: 'm/s-to-kg/ms'

--- a/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/discover_atm_files.cwl
@@ -21,7 +21,7 @@ requirements:
               parser.add_argument(
                   '-e', '--end-year', help="end year", type=int)
               _args = parser.parse_args(sys.argv[1:])
-              
+
               inpath = _args.input
               if not os.path.exists(inpath):
                   print("ERROR: directory not found {}".format(inpath), file=sys.stderr)
@@ -34,18 +34,15 @@ requirements:
               atm_files = list()
 
               for root, dirs, files in os.walk(inpath):
-                  if not files or dirs:
-                      continue
-
-                  for f in files:
-                      if re.search(atm_pattern, f):
-                          atm_files.append(os.path.join(root, f))
+                for f in files:
+                  if re.search(atm_pattern, f):
+                    atm_files.append(os.path.join(root, f))
 
               for f in sorted(atm_files):
                   print(f)
 
               return 0
-              
+
           if __name__ == "__main__":
               sys.exit(main())
 

--- a/scripts/cwl_workflows/atm-highfreq/find_start_end.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/find_start_end.cwl
@@ -15,8 +15,8 @@ requirements:
 
           def get_year(filename):
               # r"(?<=\.)(\d*?)(?=\-\d{2}.nc)" matches "1850" from "somelongcasename.cam.h0.1850-12.nc"
-              # r"^(\d{4})(?=\d{4}) matches "2018" from "20180129.DECKv1b_piControl.ne30_oEC.edison.cam.h1.0002-02-25-00000.nc"
-              year_patterns = [r"(?<=\.)(\d*?)(?=\-\d{2}.nc)", r"^(\d{4})(?=\d{4})"]
+              # r"(?<=\.)(\d*?)(?=\-\d{2}-\d{2})" matches "0002" from "20180129.DECKv1b_piControl.ne30_oEC.edison.cam.h1.0002-02-25-00000.nc"
+              year_patterns = [r"(?<=\.)(\d*?)(?=\-\d{2}.nc)", r"(?<=\.)(\d*?)(?=\-\d{2}-\d{2})"]
 
               year = None
               for pattern in year_patterns:

--- a/scripts/cwl_workflows/atm-highfreq/find_start_end.cwl
+++ b/scripts/cwl_workflows/atm-highfreq/find_start_end.cwl
@@ -12,19 +12,28 @@ requirements:
           import os
           import re
           import json
-          def get_year(filepath):
-              # Works for files matching the pattern: "somelongcasename.cam.h0.1850-12.nc"
-              _, name = os.path.split(filepath)
-              pattern = r'[c|e]am\.h\d'
-              s = re.search(pattern, name)
-              if not s:
-                raise ValueError(f"Unable to find year for file {name}")
-              return int(name[s.end() + 1: s.end() + 5])
+
+          def get_year(filename):
+              # r"(?<=\.)(\d*?)(?=\-\d{2}.nc)" matches "1850" from "somelongcasename.cam.h0.1850-12.nc"
+              # r"^(\d{4})(?=\d{4}) matches "2018" from "20180129.DECKv1b_piControl.ne30_oEC.edison.cam.h1.0002-02-25-00000.nc"
+              year_patterns = [r"(?<=\.)(\d*?)(?=\-\d{2}.nc)", r"^(\d{4})(?=\d{4})"]
+
+              year = None
+              for pattern in year_patterns:
+                  year = re.search(pattern, filename)
+                  if year is not None:
+                      break
+
+              if year is None:
+                  raise ValueError(f"Unable to find year for file {filename}")
+              return int(year.group(0))
+
           def main():
               parser = argparse.ArgumentParser()
               parser.add_argument('--data-path')
 
-              years = sorted([get_year(x) for x in os.listdir(parser.parse_args().data_path)])
+              filenames = [filename for filename in os.listdir(parser.parse_args().data_path) if '.nc' in filename]
+              years = sorted([get_year(filename) for filename in filenames])
               with open("cwl.output.json", "w") as output:
                 json.dump({"start_year": years[0], "end_year": years[-1]}, output)
               return 0


### PR DESCRIPTION
Summary of Changes
* Update logic in `get_year()` in `find_start_end.cwl` to parse the correct regex pattern for years (monthly and sub-monthly)
* Update `discover_atm_files` to parse the correct files for their absolute paths to return `atm_files` list
* Revert changes related to https://github.com/E3SM-Project/e3sm_to_cmip/commit/b54dea7af29202fab6f2b5895fa69e7b7c31aca2#diff-9cc8b4180a30ce9a2a9dd6676bc74fd450b01f055d677e3a59005c305bea0bd7
   *  `pr_highfreq` should not be defined as default handler because it is not listed in `CMIP6_day.json`. 
* Remove `rlut_highfreq` from `default_handler_info.yaml` and add `rlut_highfreq.py`, which is based on `rlut.py` with some minor tweaks