### PR TITLE
Add workflow support eam/elm v2 ouput on LCRC

### DIFF
--- a/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-3hr.yaml
+++ b/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-3hr.yaml
@@ -1,0 +1,37 @@
+# path to the raw model data
+data_path: /lcrc/group/e3sm/ac.zhang40/E3SMv2/v2.LR.historical_0101/archive/atm/hist/3hr
+
+# size of output data files in years
+frequency: 15
+
+# the sampling frequency of the data itself
+sample_freq: 3hr
+
+# the number of time steps per day
+time_steps_per_day: '8'
+
+# number of ncremap workers
+num_workers: 12
+
+# slurm account info
+account: condo
+partition: acme-small
+timeout: 4:00:00
+
+# horizontal regridding file path
+hrz_atm_map_path: /lcrc/group/e3sm/zender/maps/map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
+
+# path to CMIP6 tables directory
+tables_path: /home/ac.zhang40/cmip6-cmor-tables/Tables/
+
+# path to CMOR case metadata
+metadata_path: /home/ac.zhang40/CMIP6-Metadata/template.json
+
+# list if E3SM raw variable names
+std_var_list: [PRECT]
+#std_var_list: [FLUT, QREFHT]
+
+# list of CMIP6 variable names
+std_cmor_list: [pr_highfreq]
+
+

--- a/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-day.yaml
+++ b/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-day.yaml
@@ -1,0 +1,37 @@
+# path to the raw model data
+data_path: /lcrc/group/e3sm/ac.zhang40/E3SMv2/v2.LR.historical_0101/archive/atm/hist/day
+
+# size of output data files in years
+frequency: 15
+
+# the sampling frequency of the data itself
+sample_freq: day
+
+# the number of time steps per day
+time_steps_per_day: '1'
+
+# number of ncremap workers
+num_workers: 12
+
+# slurm account info
+account: condo
+partition: acme-small
+timeout: 4:00:00
+
+# horizontal regridding file path
+hrz_atm_map_path: /lcrc/group/e3sm/zender/maps/map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
+
+# path to CMIP6 tables directory
+tables_path: /home/ac.zhang40/cmip6-cmor-tables/Tables/
+
+# path to CMOR case metadata
+metadata_path: /home/ac.zhang40/CMIP6-Metadata/template.json
+
+# list if E3SM raw variable names
+std_var_list: [TREFHTMN, TREFHTMX, TREFHT, QREFHT, FLUT, PRECT]
+#std_var_list: [FLUT, QREFHT]
+
+# list of CMIP6 variable names
+std_cmor_list: [tasmin, tasmax, tas, huss, rlut_highfreq, pr_highfreq]
+
+

--- a/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq.cwl
@@ -1,0 +1,97 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: SubworkflowFeatureRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: ScatterFeatureRequirement
+
+inputs:
+
+  data_path: string
+  metadata_path: string
+
+  frequency: int
+  sample_freq: string
+  time_steps_per_day: string
+  num_workers: int
+  tables_path: string
+
+  hrz_atm_map_path: string
+  
+  std_var_list: string[]
+  std_cmor_list: string[]
+
+  account: string
+  partition: string
+  timeout: string
+
+outputs:
+  cmorized:
+    type: Directory
+    outputSource: 
+      - step_std_cmor/cmip6_dir
+
+steps:
+  step_find_casename:
+    run: find_casename.cwl
+    in:
+      atm_data_path: data_path
+    out:
+      - casename
+  
+  step_find_start_end:
+    run: find_start_end.cwl
+    in:
+      data_path: data_path
+    out:
+      - start_year
+      - end_year
+
+  step_discover_atm_files:
+    run: discover_atm_files.cwl
+    in:
+      input: data_path
+    out:
+      - atm_files
+  
+  step_pull_paths:
+    run: file_to_string_list.cwl
+    in:
+      a_File: step_discover_atm_files/atm_files
+    out:
+      - list_of_strings
+
+  step_std_hrz_remap:
+    run: hrzremap_posin_paths.cwl
+    in:
+      casename: step_find_casename/casename
+      variables: std_var_list
+      start_year: step_find_start_end/start_year
+      end_year: step_find_start_end/end_year
+      year_per_file: frequency
+      num_workers: num_workers
+      mapfile: hrz_atm_map_path
+      input_files: step_pull_paths/list_of_strings
+      account: account
+      partition: partition
+      timeout: timeout
+      time_steps_per_day: time_steps_per_day
+    out:
+      - time_series_files
+  
+  step_std_cmor:
+    run: cmor.cwl
+    in:
+      tables_path: tables_path
+      metadata_path: metadata_path
+      sample_freq: sample_freq
+      num_workers: num_workers
+      var_list: std_cmor_list
+      raw_file_list: step_std_hrz_remap/time_series_files
+      account: account
+      partition: partition
+      timeout: timeout
+    out:
+      - cmip6_dir

--- a/scripts/cwl_workflows/atm-highfreq-eam/cmor.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/cmor.cwl
@@ -1,0 +1,57 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing: 
+      - $(inputs.raw_file_list)
+inputs:
+  tables_path:
+    type: string
+    inputBinding:
+      prefix: --tables-path
+  metadata_path:
+    type: string
+    inputBinding:
+      prefix: --user-metadata
+  num_workers:
+    type: int
+    inputBinding:
+      prefix: --num-proc
+  var_list:
+    type: string[]
+  raw_file_list:
+    type: File[]
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+  sample_freq:
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - e3sm_to_cmip
+  - --serial
+  - --freq=$(inputs.sample_freq)
+  - prefix: --output-path
+    valueFrom: $(runtime.outdir)
+  - prefix: --var-list
+    valueFrom: $(inputs.var_list.join(", "))
+  - prefix: --input-path
+    valueFrom: "."
+
+outputs:
+  cmip6_dir: 
+    type: Directory
+    outputBinding:
+      glob: CMIP6

--- a/scripts/cwl_workflows/atm-highfreq-eam/discover_atm_files.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/discover_atm_files.cwl
@@ -1,0 +1,58 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, discover_atm_files.py]
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: discover_atm_files.py
+        entry: |
+          import os
+          import sys
+          import re
+          import argparse
+
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument(
+                  '-i', '--input', help="root input path")
+              parser.add_argument(
+                  '-s', '--start-year', help="start year", type=int)
+              parser.add_argument(
+                  '-e', '--end-year', help="end year", type=int)
+              _args = parser.parse_args(sys.argv[1:])
+
+              inpath = _args.input
+              if not os.path.exists(inpath):
+                  print("ERROR: directory not found {}".format(inpath), file=sys.stderr)
+                  return 1
+
+              start = _args.start_year
+              end = _args.end_year
+
+              atm_pattern = r'[c|e]am\.h\d'
+              atm_files = list()
+
+              for root, dirs, files in os.walk(inpath):
+                for f in files:
+                  if re.search(atm_pattern, f):
+                    atm_files.append(os.path.join(root, f))
+
+              for f in sorted(atm_files):
+                  print(f)
+
+              return 0
+
+          if __name__ == "__main__":
+              sys.exit(main())
+
+stdout: atm_files.txt
+inputs:
+  input:
+    type: string
+    inputBinding:
+      prefix: --input
+
+outputs:
+  atm_files:
+    type: stdout

--- a/scripts/cwl_workflows/atm-highfreq-eam/file_to_string_list.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/file_to_string_list.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+
+inputs:
+  a_File: File
+
+baseCommand: python
+arguments:
+ - prefix: -c
+   valueFrom: |
+    import json
+    list_of_strings = []
+    with open("$(inputs.a_File.path)", "r") as infile:
+      list_of_strings = infile.read().split()
+    with open("cwl.output.json", "w") as output:
+      json.dump({"list_of_strings": list_of_strings}, output)
+
+outputs:
+  list_of_strings: string[]

--- a/scripts/cwl_workflows/atm-highfreq-eam/find_casename.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/find_casename.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, find_casename.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: find_casename.py
+        entry: |
+          import os
+          import sys
+          import argparse
+          import json
+          import re
+          def main():
+              p = argparse.ArgumentParser()
+              p.add_argument('--atm-data-path')
+              args = p.parse_args()
+              filename = os.listdir(args.atm_data_path)[0]
+              pattern = r'[c|e]am\.h\d'
+              s = re.search(pattern, filename)
+              if not s:
+                  return -1
+              with open("cwl.output.json", "w") as output:
+                  json.dump({"casename": filename[:s.start()]}, output)
+          if __name__ == "__main__":
+              sys.exit(main())
+
+inputs:
+  atm_data_path:
+    type: string
+    inputBinding:
+      prefix: --atm-data-path
+
+outputs:
+  casename:
+    type: string

--- a/scripts/cwl_workflows/atm-highfreq-eam/find_start_end.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/find_start_end.cwl
@@ -1,0 +1,50 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, get_start_end.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_start_end.py
+        entry: |
+          import argparse
+          import sys
+          import os
+          import re
+          import json
+
+          def get_year(filename):
+              # r"(?<=\.)(\d*?)(?=\-\d{2}.nc)" matches "1850" from "somelongcasename.cam.h0.1850-12.nc"
+              # r"(?<=\.)(\d*?)(?=\-\d{2}-\d{2})" matches "0002" from "20180129.DECKv1b_piControl.ne30_oEC.edison.cam.h1.0002-02-25-00000.nc"
+              year_patterns = [r"(?<=\.)(\d*?)(?=\-\d{2}.nc)", r"(?<=\.)(\d*?)(?=\-\d{2}-\d{2})"]
+
+              year = None
+              for pattern in year_patterns:
+                  year = re.search(pattern, filename)
+                  if year is not None:
+                      break
+
+              if year is None:
+                  raise ValueError(f"Unable to find year for file {filename}")
+              return int(year.group(0))
+
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--data-path')
+
+              filenames = [filename for filename in os.listdir(parser.parse_args().data_path) if '.nc' in filename]
+              years = sorted([get_year(filename) for filename in filenames])
+              with open("cwl.output.json", "w") as output:
+                json.dump({"start_year": years[0], "end_year": years[-1]}, output)
+              return 0
+          if __name__ == "__main__":
+              sys.exit(main())
+inputs:
+  data_path:
+    type: string
+    inputBinding:
+      prefix: --data-path
+
+outputs:
+  start_year: int
+  end_year: int

--- a/scripts/cwl_workflows/atm-highfreq-eam/generate_segments.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/generate_segments.cwl
@@ -1,0 +1,83 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, generate_segments.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: generate_segments.py
+        entry: |
+          import sys
+          import argparse
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--start')
+              parser.add_argument('--end')
+              parser.add_argument('--frequency')
+              _args = parser.parse_args(sys.argv[1:])
+
+              start = int(_args.start)
+              end = int(_args.end)
+              freq = int(_args.frequency)
+
+              seg_start = start
+              seg_end = start + freq - 1
+
+              start_outname = 'segments_start_{}_{}.txt'.format(start, end)
+              end_outname = 'segments_end_{}_{}.txt'.format(start, end)
+
+              with open(start_outname, 'w') as segstart:
+                  with open(end_outname, 'w') as segend:
+
+                      while seg_end < end:
+                          segstart.write("{}\n".format(seg_start))
+                          segend.write("{}\n".format(seg_end))
+                          seg_start += freq
+                          seg_end += freq
+                      if seg_end == end:
+                          segstart.write("{}".format(seg_start))
+                          segend.write("{}".format(seg_end))
+                      if seg_end > end:
+                          segstart.write("{}\n".format(seg_end - freq + 1))
+                          segend.write("{}\n".format(end))
+              return 0
+          if __name__ == "__main__":
+              sys.exit(main())
+
+inputs:
+  start:
+    type: int
+    inputBinding:
+      prefix: --start
+  end:
+    type: int
+    inputBinding:
+      prefix: --end
+  frequency:
+    type: int
+    inputBinding:
+      prefix: --frequency
+
+outputs:
+  segments_start:
+    type: int[]
+    outputBinding:
+      glob: segments_start*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )
+  segments_end:
+    type: int[]
+    outputBinding:
+      glob: segments_end*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )

--- a/scripts/cwl_workflows/atm-highfreq-eam/hrzremap_posin_paths.cwl
+++ b/scripts/cwl_workflows/atm-highfreq-eam/hrzremap_posin_paths.cwl
@@ -1,0 +1,71 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  variables:
+    type: string[]
+  start_year:
+    type: int
+  end_year:
+    type: int
+  year_per_file:
+    type: int
+  mapfile:
+    type: string
+  casename:
+    type: string
+  input_files:
+    type: string[]
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+  time_steps_per_day:
+    type: string
+  num_workers:
+    type: int
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - ncclimo
+  - '-7'
+  - --dfl_lvl=1
+  - --no_cll_msr
+  - --no_stdin
+  - --job_nbr=$(inputs.num_workers)
+  - --thr_nbr=$(inputs.num_workers)
+  - --clm_md=hgh_frq_spl
+  - --timesteps_per_day=$(inputs.time_steps_per_day)
+  - -O
+  - $(runtime.outdir)
+  - -o
+  - ./native
+  - -v
+  - $(inputs.variables.join(" "))
+  - -s
+  - $(inputs.start_year)
+  - -e
+  - $(inputs.end_year)
+  - $("--ypf=" + inputs.year_per_file)
+  - $("--map=" + inputs.mapfile)
+  - -c
+  - $(inputs.casename)
+  - $(inputs.input_files)
+
+outputs:
+  time_series_files:
+    type: File[]
+    outputBinding:
+      glob: 
+        - "*.nc"

--- a/scripts/cwl_workflows/atm-unified-eam/atm-unified-job.yaml
+++ b/scripts/cwl_workflows/atm-unified-eam/atm-unified-job.yaml
@@ -1,0 +1,38 @@
+
+# path to the raw model data
+data_path: /lcrc/group/e3sm/ac.zhang40/E3SMv2/v2.LR.historical_0101/archive/atm/hist
+
+# size of output data files in years
+frequency: 15
+
+# number of ncremap workers
+num_workers: 12
+
+# slurm account info
+account: condo
+partition: acme-small
+timeout: 2:00:00
+
+# horizontal regridding file path
+hrz_atm_map_path: /lcrc/group/e3sm/zender/maps/map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
+
+# vertical interpolation remap file path
+vrt_map_path: /home/ac.zhang40/e3sm_to_cmip/e3sm_to_cmip/resources/vrt_remap_plev19.nc
+
+# path to CMIP6 tables directory
+tables_path: /home/ac.zhang40/cmip6-cmor-tables/Tables/
+
+# path to CMOR case metadata
+metadata_path: /home/ac.zhang40/CMIP6-Metadata/template.json
+
+# list if 2D E3SM raw variable names
+std_var_list: [hyam, hybm, hyai, hybi, TREFHT, TS, PSL, PS, U10, QREFHT, PRECC, PRECL, PRECSC, PRECSL, QFLX, TAUX, TAUY, LHFLX, CLDTOT, FLDS, FLNS, FSDS, FSNS, SHFLX, CLOUD, CLDICE, TGCLDIWP, CLDLIQ, TGCLDCWP, TMQ, FLNSC, FSNTOA, FSNT, FLNT, FLUTC, FSDSC, SOLIN, FSNSC, FSUTOA, FSUTOAC, AODABS, AODVIS, AREL]
+
+# list of 2D CMIP6 variable names
+std_cmor_list: [pfull, phalf, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, cl, clw, cli, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, reffclwtop, rsdscs]
+
+# list if 3D E3SM raw variable names
+plev_var_list: [Q,   O3, T,  U,  V,  Z3, RELHUM, OMEGA]
+
+# list of 3D CMIP6 variable names
+plev_cmor_list: [hus, o3, ta, ua, va, zg, hur,    wap]

--- a/scripts/cwl_workflows/atm-unified-eam/atm-unified.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/atm-unified.cwl
@@ -1,0 +1,186 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: SubworkflowFeatureRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: ScatterFeatureRequirement
+
+inputs:
+
+  data_path: string
+  metadata_path: string
+
+  frequency: int
+  num_workers: int
+  tables_path: string
+
+  hrz_atm_map_path: string
+  vrt_map_path: string
+  
+  std_var_list: string[]
+  std_cmor_list: string[]
+  
+  plev_var_list: string[]
+  plev_cmor_list: string[]
+
+  account: string
+  partition: string
+  timeout: string
+
+outputs:
+  cmorized:
+    type: Directory[]
+    outputSource: 
+      - step_std_cmor/cmip6_dir
+      - step_plev_cmor/cmip6_dir
+    linkMerge: merge_flattened
+  # logs:
+  #   type: Directory[]
+  #   outputSource:
+  #     - step_std_cmor/cmor_logs
+  #     - step_plev_cmor/cmor_logs
+  #   linkMerge: merge_flattened
+
+steps:
+  step_find_casename:
+    run: find_casename.cwl
+    in:
+      atm_data_path: data_path
+    out:
+      - casename
+  
+  step_find_start_end:
+    run: find_start_end.cwl
+    in:
+      data_path: data_path
+    out:
+      - start_year
+      - end_year
+  
+  step_segments:
+    run: generate_segments.cwl
+    in:
+      start: step_find_start_end/start_year
+      end: step_find_start_end/end_year
+      frequency: frequency
+    out:
+      - segments_start
+      - segments_end
+
+  step_discover_atm_files:
+    run: discover_atm_files.cwl
+    in:
+      input: data_path
+      start: step_segments/segments_start
+      end: step_segments/segments_end
+    scatter:
+      - start
+      - end
+    scatterMethod: 
+      dotproduct
+    out:
+      - atm_files
+  
+  step_pull_paths:
+    run: file_to_string_list.cwl
+    scatter:
+      a_File
+    in:
+      a_File: step_discover_atm_files/atm_files
+    out:
+      - list_of_strings
+
+  step_std_hrz_remap:
+    run: hrzremap_posin_paths.cwl
+    scatter:
+      - input_files
+      - start_year
+      - end_year
+    scatterMethod: 
+      dotproduct
+    in:
+      casename: step_find_casename/casename
+      variables: std_var_list
+      start_year: step_segments/segments_start
+      end_year: step_segments/segments_end
+      year_per_file: frequency
+      mapfile: hrz_atm_map_path
+      input_files: step_pull_paths/list_of_strings
+      account: account
+      partition: partition
+      timeout: timeout
+    out:
+      - time_series_files
+  
+  step_std_cmor:
+    run: cmor.cwl
+    scatter:
+      - raw_file_list
+    in:
+      tables_path: tables_path
+      metadata_path: metadata_path
+      num_workers: num_workers
+      var_list: std_cmor_list
+      raw_file_list: step_std_hrz_remap/time_series_files
+      account: account
+      partition: partition
+      timeout: timeout
+    out:
+      - cmip6_dir
+#      - cmor_logs
+
+  step_vrt_remap:
+    run: vrtremap.cwl
+    scatter:
+      - infiles
+    in:
+      infiles: step_pull_paths/list_of_strings
+      vrtmap: vrt_map_path
+      casename: step_find_casename/casename
+      num_workers: num_workers
+      account: account
+      partition: partition
+      timeout: timeout
+    out: 
+      - vrt_remapped_file
+  
+  step_plev_hrz_remap:
+    run: hrzremap_posin.cwl
+    scatter:
+      - input_files
+      - start_year
+      - end_year
+    scatterMethod:
+      dotproduct
+    in:
+      casename: step_find_casename/casename
+      variables: plev_var_list
+      start_year: step_segments/segments_start
+      end_year: step_segments/segments_end
+      year_per_file: frequency
+      mapfile: hrz_atm_map_path
+      input_files: step_vrt_remap/vrt_remapped_file
+      account: account
+      partition: partition
+      timeout: timeout
+    out:
+      - time_series_files
+  
+  step_plev_cmor:
+    run: cmor.cwl
+    scatter:
+      - raw_file_list
+    in:
+      tables_path: tables_path
+      metadata_path: metadata_path
+      num_workers: num_workers
+      var_list: plev_cmor_list
+      raw_file_list: step_plev_hrz_remap/time_series_files
+      account: account
+      partition: partition
+      timeout: timeout
+    out:
+      - cmip6_dir
+      # - cmor_logs

--- a/scripts/cwl_workflows/atm-unified-eam/cmor.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/cmor.cwl
@@ -1,0 +1,57 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing: 
+      - $(inputs.raw_file_list)
+inputs:
+  tables_path:
+    type: string
+    inputBinding:
+      prefix: --tables-path
+  metadata_path:
+    type: string
+    inputBinding:
+      prefix: --user-metadata
+  num_workers:
+    type: int
+    inputBinding:
+      prefix: --num-proc
+  var_list:
+    type: string[]
+  raw_file_list:
+    type: File[]
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - e3sm_to_cmip
+  - prefix: --output-path
+    valueFrom: $(runtime.outdir)
+  - prefix: --var-list
+    valueFrom: $(inputs.var_list.join(", "))
+  - prefix: --input-path
+    valueFrom: "."
+
+outputs:
+  cmip6_dir: 
+    type: Directory
+    outputBinding:
+      glob: CMIP6
+  # cmor_logs:
+  #   type: Directory
+  #   outputBinding:
+  #     glob: cmor_logs

--- a/scripts/cwl_workflows/atm-unified-eam/discover_atm_files.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/discover_atm_files.cwl
@@ -1,0 +1,78 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, discover_atm_files.py]
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: discover_atm_files.py
+        entry: |
+          import os
+          import sys
+          import re
+          import argparse
+
+          def get_year(filename):
+
+              pattern = r'\d{4}-\d{2}'
+              idx = re.search(pattern, filename)
+              if idx is None:
+                  print(filename)
+              return int( filename[idx.start(): idx.end()-3] )
+
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument(
+                  '-i', '--input', help="root input path")
+              parser.add_argument(
+                  '-s', '--start-year', help="start year", type=int)
+              parser.add_argument(
+                  '-e', '--end-year', help="end year", type=int)
+              _args = parser.parse_args(sys.argv[1:])
+              
+              inpath = _args.input
+              if not os.path.exists(inpath):
+                  print("ERROR: directory not found {}".format(inpath), file=sys.stderr)
+                  return 1
+
+              start = _args.start_year
+              end = _args.end_year
+
+              #atm_pattern = 'cam.h0'
+              atm_pattern = 'eam.h0'
+              atm_files = list()
+
+              for root, _, files in os.walk(inpath):
+                  if files:
+                      for f in files:
+                          if atm_pattern in f:
+                              year = get_year(f)
+                              if year >= start and year <= end:
+                                  atm_files.append(os.path.join(root, f))
+
+              for f in sorted(atm_files):
+                  print(f)
+
+              return 0
+              
+          if __name__ == "__main__":
+              sys.exit(main())
+
+stdout: atm_files.txt
+inputs:
+  input:
+    type: string
+    inputBinding:
+      prefix: --input
+  start:
+    type: int
+    inputBinding:
+      prefix: --start
+  end:
+    type: int
+    inputBinding:
+      prefix: --end
+
+outputs:
+  atm_files:
+    type: stdout

--- a/scripts/cwl_workflows/atm-unified-eam/file_to_string_list.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/file_to_string_list.cwl
@@ -1,0 +1,21 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+
+inputs:
+  a_File: File
+
+baseCommand: python
+
+arguments:
+ - prefix: -c
+   valueFrom: |
+    import json
+    list_of_strings = []
+    with open("$(inputs.a_File.path)", "r") as infile:
+      list_of_strings = infile.read().split()
+    with open("cwl.output.json", "w") as output:
+      json.dump({"list_of_strings": list_of_strings}, output)
+
+outputs:
+  list_of_strings: string[]

--- a/scripts/cwl_workflows/atm-unified-eam/find_casename.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/find_casename.cwl
@@ -1,0 +1,36 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, find_casename.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: find_casename.py
+        entry: |
+          import os
+          import sys
+          import argparse
+          import json
+          def main():
+              p = argparse.ArgumentParser()
+              p.add_argument('--atm-data-path')
+              args = p.parse_args()
+              filename = os.listdir(args.atm_data_path)[0]
+              i = filename.index('.eam.h0')
+              if i == -1:
+                  return -1
+              with open("cwl.output.json", "w") as output:
+                  json.dump({"casename": filename[:i]}, output)
+          if __name__ == "__main__":
+              sys.exit(main())
+
+inputs:
+  atm_data_path:
+    type: string
+    inputBinding:
+      prefix: --atm-data-path
+
+outputs:
+  casename:
+    type: string

--- a/scripts/cwl_workflows/atm-unified-eam/find_start_end.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/find_start_end.cwl
@@ -1,0 +1,47 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, get_start_end.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_start_end.py
+        entry: |
+          import argparse
+          import sys
+          import os
+          def get_year(filepath):
+              # Works for files matching the pattern: "somelongcasename.eam.h0.1850-12.nc"
+              return filepath[-10:-6]
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--data-path')
+
+              files = sorted([get_year(x) for x in os.listdir(parser.parse_args().data_path)])
+              with open('start.txt', 'w') as start_out, open('end.txt', 'w') as end_out:
+                start_out.write(files[0])
+                end_out.write(files[-1])
+                print("Data files found from years {} to {} ".format(files[0], files[-1]))
+              return 0
+          if __name__ == "__main__":
+              sys.exit(main())
+inputs:
+  data_path:
+    type: string
+    inputBinding:
+      prefix: --data-path
+
+outputs:
+  start_year:
+    type: int
+    outputBinding:
+      glob: start.txt
+      loadContents: true
+      outputEval: |
+        $( parseInt(self[0].contents) )
+  end_year:
+    type: int
+    outputBinding:
+      glob: end.txt
+      loadContents: true
+      outputEval: $( parseInt(self[0].contents) )

--- a/scripts/cwl_workflows/atm-unified-eam/generate_segments.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/generate_segments.cwl
@@ -1,0 +1,83 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, generate_segments.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: generate_segments.py
+        entry: |
+          import sys
+          import argparse
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--start')
+              parser.add_argument('--end')
+              parser.add_argument('--frequency')
+              _args = parser.parse_args(sys.argv[1:])
+
+              start = int(_args.start)
+              end = int(_args.end)
+              freq = int(_args.frequency)
+
+              seg_start = start
+              seg_end = start + freq - 1
+
+              start_outname = 'segments_start_{}_{}.txt'.format(start, end)
+              end_outname = 'segments_end_{}_{}.txt'.format(start, end)
+
+              with open(start_outname, 'w') as segstart:
+                  with open(end_outname, 'w') as segend:
+
+                      while seg_end < end:
+                          segstart.write("{}\n".format(seg_start))
+                          segend.write("{}\n".format(seg_end))
+                          seg_start += freq
+                          seg_end += freq
+                      if seg_end == end:
+                          segstart.write("{}".format(seg_start))
+                          segend.write("{}".format(seg_end))
+                      if seg_end > end:
+                          segstart.write("{}\n".format(seg_end - freq + 1))
+                          segend.write("{}\n".format(end))
+              return 0
+          if __name__ == "__main__":
+              sys.exit(main())
+
+inputs:
+  start:
+    type: int
+    inputBinding:
+      prefix: --start
+  end:
+    type: int
+    inputBinding:
+      prefix: --end
+  frequency:
+    type: int
+    inputBinding:
+      prefix: --frequency
+
+outputs:
+  segments_start:
+    type: int[]
+    outputBinding:
+      glob: segments_start*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )
+  segments_end:
+    type: int[]
+    outputBinding:
+      glob: segments_end*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )

--- a/scripts/cwl_workflows/atm-unified-eam/hrzremap_posin.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/hrzremap_posin.cwl
@@ -1,0 +1,68 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  variables:
+    type: string[]
+  start_year:
+    type: int
+  end_year:
+    type: int
+  year_per_file:
+    type: int
+  mapfile:
+    type: string
+  casename:
+    type: string
+  input_files:
+    type: File[]
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - ncclimo
+  - '-7'
+  - --dfl_lvl=1
+  - --no_cll_msr
+  - --no_stdin
+  - -P
+  - "eam"
+  - -a
+  - sdd
+  - --regrid_options="--rnr=0.0"
+  - -O
+  - $(runtime.outdir)
+  - -o
+  - ./native
+  - -v
+  - $(inputs.variables.join(" "))
+  - -s
+  - $(inputs.start_year)
+  - -e
+  - $(inputs.end_year)
+  - $("--ypf=" + inputs.year_per_file)
+  - $("--map=" + inputs.mapfile)
+  - -c
+  - $(inputs.casename)
+  - $(inputs.input_files)
+
+outputs:
+  time_series_files:
+    type: File[]
+    outputBinding:
+      glob: 
+        - "*.nc"

--- a/scripts/cwl_workflows/atm-unified-eam/hrzremap_posin_paths.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/hrzremap_posin_paths.cwl
@@ -1,0 +1,67 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  variables:
+    type: string[]
+  start_year:
+    type: int
+  end_year:
+    type: int
+  year_per_file:
+    type: int
+  mapfile:
+    type: string
+  casename:
+    type: string
+  input_files:
+    type: string[]
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - ncclimo
+  - '-7'
+  - --dfl_lvl=1
+  - --no_cll_msr
+  - --no_stdin
+  - -P
+  - "eam"
+  - -a
+  - sdd
+  - -O
+  - $(runtime.outdir)
+  - -o
+  - ./native
+  - -v
+  - $(inputs.variables.join(" "))
+  - -s
+  - $(inputs.start_year)
+  - -e
+  - $(inputs.end_year)
+  - $("--ypf=" + inputs.year_per_file)
+  - $("--map=" + inputs.mapfile)
+  - -c
+  - $(inputs.casename)
+  - $(inputs.input_files)
+
+outputs:
+  time_series_files:
+    type: File[]
+    outputBinding:
+      glob: 
+        - "*.nc"

--- a/scripts/cwl_workflows/atm-unified-eam/vrtremap.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/vrtremap.cwl
@@ -1,0 +1,95 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: vrtremap.py
+        entry: |
+          import sys
+          import os
+          import argparse
+
+          from multiprocessing import Pool
+          from subprocess import Popen, PIPE
+
+          def vrt_remap(inpath, outpath, vrtfl):
+              _, head = os.path.split(inpath)
+              output_path = os.path.join(outpath, head)
+              print("Running vertical interpolation for: {}".format(inpath))
+              cmd = ['ncks', '--rgr', 'xtr_mth=mss_val', '--vrt_fl={}'.format(vrtfl), inpath, output_path]
+              out, err = Popen(cmd, stderr=PIPE, stdout=PIPE).communicate()
+              if err:
+                  print(err)
+              return out
+
+          def run_ncks():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--vrt_fl')
+              parser.add_argument('--output')
+              parser.add_argument('--num_workers', type=int)
+              parser.add_argument('--infiles', nargs="*")
+              _args = parser.parse_args(sys.argv[1:])
+
+              pool = Pool(_args.num_workers)
+              res = list()
+
+              for inpath in _args.infiles:
+                  if not os.path.exists(inpath):
+                      print("Error: {} does not exist".format(inpath))
+                      return 1
+                  else:
+                    res.append(
+                        pool.apply_async(
+                            vrt_remap,
+                            args=(inpath.strip(), _args.output, _args.vrt_fl)))
+
+              for r in res:
+                  r.get(999999)
+              return 0
+
+          if __name__ == "__main__":
+              sys.exit(run_ncks())
+
+inputs:
+  vrtmap:
+    type: string
+  infiles:
+    type: string[]
+  num_workers:
+    type: int
+  casename:
+    type: string
+  account: 
+    type: string
+  partition: 
+    type: string
+  timeout: 
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - python
+  - vrtremap.py
+  - --output
+  - $(runtime.outdir)
+  - --vrt_fl
+  - $(inputs.vrtmap)
+  - --num_workers
+  - $(inputs.num_workers)
+  - --infiles
+  - $(inputs.infiles)
+
+outputs:
+  vrt_remapped_file:
+    type: File[]
+    outputBinding:
+      glob:
+        $(inputs.casename).eam.h0.[0-9][0-9][0-9][0-9]-[0-9][0-9].nc

--- a/scripts/cwl_workflows/lnd-elm/cmor.cwl
+++ b/scripts/cwl_workflows/lnd-elm/cmor.cwl
@@ -1,0 +1,60 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing: 
+      - $(inputs.raw_file_list)
+inputs:
+  tables_path:
+    type: string
+    inputBinding:
+      prefix: --tables-path
+  metadata_path:
+    type: string
+    inputBinding:
+      prefix: --user-metadata
+  num_workers:
+    type: int
+    inputBinding:
+      prefix: --num-proc
+  var_list:
+    type: string[]
+    inputBinding:
+      prefix: -v
+  raw_file_list:
+    type: File[]
+  account:
+    type: string
+  partition:
+    type: string
+  timeout:
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - e3sm_to_cmip
+  - -s
+  - --input-path
+  - .
+  - --output-path
+  - $(runtime.outdir)
+  - --realm
+  - lnd
+
+outputs: 
+  cmip6_dir: 
+    type: Directory
+    outputBinding:
+      glob: CMIP6
+  # logs:
+  #   type: Directory
+  #   outputBinding:
+  #     glob: cmor_logs

--- a/scripts/cwl_workflows/lnd-elm/discover_lnd_files.cwl
+++ b/scripts/cwl_workflows/lnd-elm/discover_lnd_files.cwl
@@ -1,0 +1,84 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, discover_lnd_files.py]
+stdout: lnd_files.txt
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: discover_lnd_files.py
+        entry: |
+          import os
+          import sys
+          import re
+          import argparse
+
+          def get_year(filename):
+
+              pattern = r'\d{4}-\d{2}'
+              idx = re.search(pattern, filename)
+              if idx is None:
+                  print(filename)
+              return int( filename[idx.start(): idx.end()-3] )
+
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument(
+                  '-i', '--input', help="root input path")
+              parser.add_argument(
+                  '-s', '--start-year', help="start year")
+              parser.add_argument(
+                  '-e', '--end-year', help="end year")
+              _args = parser.parse_args(sys.argv[1:])
+              
+              inpath = _args.input
+              start = int(_args.start_year)
+              end = int(_args.end_year)
+
+              #lnd_pattern = 'clm2.h0'
+              lnd_pattern = 'elm.h0'
+              lnd_files = list()
+
+              num_files_expected = 12 * (end - start + 1)
+
+              tobreak = False
+
+              for root, _, files in os.walk(inpath):
+                  if files:
+                      for f in files:
+                          if lnd_pattern in f:
+                              year = get_year(f)
+                              if year >= start and year <= end:
+                                  lnd_files.append(os.path.join(root, f))
+                                  if len(lnd_files) >= num_files_expected:
+                                      tobreak = True
+                                      break
+                      if tobreak:
+                          break
+
+              for f in sorted(lnd_files):
+                  print(f)
+              return 0
+
+          if __name__ == "__main__":
+              sys.exit(main())
+
+
+inputs:
+  input:
+    type: string
+    inputBinding:
+      prefix: --input
+  start:
+    type: int
+    inputBinding:
+      prefix: --start
+  end:
+    type: int
+    inputBinding:
+      prefix: --end
+
+outputs:
+  lnd_files:
+    type: stdout

--- a/scripts/cwl_workflows/lnd-elm/find_casename.cwl
+++ b/scripts/cwl_workflows/lnd-elm/find_casename.cwl
@@ -1,0 +1,36 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, find_casename.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: find_casename.py
+        entry: |
+          import os
+          import sys
+          import argparse
+          import json
+          def main():
+              p = argparse.ArgumentParser()
+              p.add_argument('--data-path')
+              args = p.parse_args()
+              filename = os.listdir(args.data_path)[0]
+              i = filename.index('.elm.h0')
+              if i == -1:
+                  return -1
+              with open("cwl.output.json", "w") as output:
+                  json.dump({"casename": filename[:i]}, output)
+          if __name__ == "__main__":
+              sys.exit(main())
+
+inputs:
+  data_path:
+    type: string
+    inputBinding:
+      prefix: --data-path
+
+outputs:
+  casename:
+    type: string

--- a/scripts/cwl_workflows/lnd-elm/generate_segments.cwl
+++ b/scripts/cwl_workflows/lnd-elm/generate_segments.cwl
@@ -1,0 +1,90 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, generate_segments.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: generate_segments.py
+        entry: |
+          import sys
+          import argparse
+
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--start')
+              parser.add_argument('--end')
+              parser.add_argument('--frequency')
+              _args = parser.parse_args(sys.argv[1:])
+
+              start = int(_args.start)
+              end = int(_args.end)
+              freq = int(_args.frequency)
+
+              seg_start = start
+              seg_end = start + freq - 1
+
+              start_outname = 'segments_start_{}_{}.txt'.format(start, end)
+              end_outname = 'segments_end_{}_{}.txt'.format(start, end)
+
+              segstart = open(start_outname, 'w')
+              segend = open(end_outname, 'w')
+
+              try:
+                  while seg_end < end:
+                      segstart.write("{}\n".format(seg_start))
+                      segend.write("{}\n".format(seg_end))
+                      seg_start += freq
+                      seg_end += freq
+                  if seg_end == end:
+                      segstart.write("{}\n".format(seg_start))
+                      segend.write("{}\n".format(seg_end))
+                  if seg_end > end:
+                      segstart.write("{}\n".format(seg_end - freq + 1))
+                      segend.write("{}\n".format(end))
+              finally:
+                  segstart.close()
+                  segend.close()
+              return 0
+
+          if __name__ == "__main__":
+              sys.exit(main())
+
+
+inputs:
+  start:
+    type: int
+    inputBinding:
+      prefix: --start
+  end:
+    type: int
+    inputBinding:
+      prefix: --end
+  frequency:
+    type: int
+    inputBinding:
+      prefix: --frequency
+
+outputs:
+  segments_start:
+    type: int[]
+    outputBinding:
+      glob: segments_start*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )
+  segments_end:
+    type: int[]
+    outputBinding:
+      glob: segments_end*
+      loadContents: true
+      outputEval: |
+        $( 
+          self[0].contents.split('\n').map(function(x){
+            return parseInt(x);
+          }).filter(function(x){return x})
+        )

--- a/scripts/cwl_workflows/lnd-elm/get_start_end.cwl
+++ b/scripts/cwl_workflows/lnd-elm/get_start_end.cwl
@@ -1,0 +1,48 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, get_start_end.py]
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_start_end.py
+        entry: |
+          import argparse
+          import sys
+          import os
+          def get_year(filepath):
+              # Works for files matching the pattern: "CASENAME.clm2.h0.1999-12.nc"
+              return filepath[-10:-6]
+          def main():
+              parser = argparse.ArgumentParser()
+              parser.add_argument('--data-path')
+
+              years = sorted([get_year(x) for x in os.listdir(parser.parse_args().data_path) if get_year(x)])
+              with open('start.txt', 'w') as start_out, open('end.txt', 'w') as end_out:
+                start_out.write(years[0])
+                end_out.write(years[-1])
+                print(f"Data files found from years {years[0]} to {years[-1]}")
+              return 0
+          if __name__ == "__main__":
+              sys.exit(main())
+inputs:
+  data_path:
+    type: string
+    inputBinding:
+      prefix: --data-path
+
+outputs:
+  start_year:
+    type: int
+    outputBinding:
+      glob: start.txt
+      loadContents: true
+      outputEval: |
+        $( parseInt(self[0].contents) )
+  end_year:
+    type: int
+    outputBinding:
+      glob: end.txt
+      loadContents: true
+      outputEval: |
+        $( parseInt(self[0].contents) )

--- a/scripts/cwl_workflows/lnd-elm/lnd-job.yaml
+++ b/scripts/cwl_workflows/lnd-elm/lnd-job.yaml
@@ -1,0 +1,34 @@
+# path to raw clm2 data
+lnd_data_path: /lcrc/group/e3sm/ac.zhang40/E3SMv2/v2.LR.historical_0101/archive/lnd/hist
+one_land_file: /lcrc/group/e3sm/ac.zhang40/E3SMv2/v2.LR.historical_0101/archive/lnd/hist/v2.LR.historical_0101.elm.h0.2000-01-01-00000.nc
+
+
+# path to CMOR case metadata
+metadata_path: /home/ac.zhang40/CMIP6-Metadata/template.json
+
+# path to grid file matching the input data
+lnd_source_grid: /lcrc/group/e3sm/zender/grids/ne30pg2.nc
+
+# path to grid file for the output data
+lnd_destination_grid: /lcrc/group/e3sm/zender/grids/cmip6_180x360_scrip.20181001.nc
+
+# number of years to put in each output file
+frequency: 15
+
+# number of ncremap workers
+num_workers: 12
+
+# path to CMIP6 tables directory
+tables_path: /home/ac.zhang40/cmip6-cmor-tables/Tables/
+
+# slurm account info
+account: condo
+partition: acme-small
+timeout: 2:00:00
+
+# list of E3SM land variable names
+lnd_var_list:  [SOILWATER_10CM, SOILLIQ, SOILICE, QOVER, QRUNOFF, QINTR, QVEGE, QSOIL, QVEGT, TSOI, LAISHA, LAISUN] # , TOTLITC, CWDC, TOTPRODC, COL_FIRE_CLOSS, WOOD_HARVESTC, TOTVEGC, NBP, GPP, AR, HR]
+
+# list of CMIP6 variable names
+cmor_var_list: [mrsos, mrso, mrfso, mrros, mrro, prveg, evspsblveg, evspsblsoi, tran, tsl, lai] #, cLitter, cProduct, cSoil, fFire, fHarvest, cVeg, nbp, gpp, ra, rh]
+

--- a/scripts/cwl_workflows/lnd-elm/lnd.cwl
+++ b/scripts/cwl_workflows/lnd-elm/lnd.cwl
@@ -1,0 +1,167 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: ScatterFeatureRequirement
+  - class: SubworkflowFeatureRequirement
+  - class: InlineJavascriptRequirement
+
+inputs:
+
+  lnd_data_path: string
+  lnd_destination_grid: string
+  lnd_source_grid: string
+  frequency: int
+  num_workers: int
+
+  metadata_path: string
+  tables_path: string
+
+  lnd_var_list: string[]
+  cmor_var_list: string[]
+
+  account: string
+  partition: string
+  timeout: string
+
+  one_land_file: string
+
+outputs: 
+  cmorized:
+    type: Directory[]
+    outputSource: step_cmor/cmip6_dir
+    linkMerge: merge_flattened
+  # cmor_logs:
+  #   type: Directory[]
+  #   outputSource: step_cmor/logs
+  # time_series:
+  #   type: File[]
+  #   outputSource: step_join_timeseries/array_1d
+
+steps:
+
+  step_get_casename:
+    run: find_casename.cwl
+    in:
+      data_path: lnd_data_path
+    out:
+      - casename
+  
+  step_get_start_end:
+    run: get_start_end.cwl
+    in:
+      data_path: lnd_data_path
+    out:
+      - start_year
+      - end_year
+
+  step_segments:
+    run: generate_segments.cwl
+    in:
+      start: step_get_start_end/start_year
+      end: step_get_start_end/end_year
+      frequency: frequency
+    out:
+      - segments_start
+      - segments_end
+
+  step_discover_lnd_files:
+    run: discover_lnd_files.cwl
+    in:
+      input: lnd_data_path
+      start: step_segments/segments_start
+      end: step_segments/segments_end
+    scatter:
+      - start
+      - end
+    scatterMethod:
+      dotproduct
+    out:
+      - lnd_files
+  
+  step_remap:
+    run:
+      ncremap_lnd.cwl
+    in:
+      destination_grid: lnd_destination_grid
+      source_grid: lnd_source_grid
+      lnd_files: step_discover_lnd_files/lnd_files
+      account: account
+      partition: partition
+      timeout: timeout
+      var_list: lnd_var_list
+      one_land_file: one_land_file
+    scatter:
+      - lnd_files
+    out:
+      - remaped_lnd_files
+  
+  time_series:
+    run: 
+      time_series_lnd.cwl
+    in:
+      casename: step_get_casename/casename
+      variable_name: lnd_var_list
+      year_per_file: frequency
+      start_year: step_segments/segments_start
+      end_year: step_segments/segments_end
+      remapped_lnd_files: step_remap/remaped_lnd_files
+      account: account
+      partition: partition
+      timeout: timeout
+    scatter:
+      - remapped_lnd_files
+      - start_year
+      - end_year
+    scatterMethod:
+      dotproduct
+    out:
+      - remaped_time_series
+
+  step_cmor:
+    run: cmor.cwl
+    in:
+      tables_path: tables_path
+      metadata_path: metadata_path
+      num_workers: num_workers
+      var_list: cmor_var_list
+      raw_file_list: time_series/remaped_time_series
+      account: account
+      partition: partition
+      timeout: timeout
+    scatter:
+      - raw_file_list
+    out:
+      - cmip6_dir
+      # - logs
+  
+  # step_join_timeseries:
+  #   run:
+  #     class: ExpressionTool
+  #     inputs:
+  #       arrayTwoDim:
+  #         type:
+  #           type: array
+  #           items:
+  #             type: array
+  #             items: File
+  #         inputBinding:
+  #           loadContents: true
+  #     outputs:
+  #       array_1d:
+  #         type: File[]
+  #     expression: >
+  #       ${
+  #         var newArray= [];
+  #         for (var i = 0; i < inputs.arrayTwoDim.length; i++) {
+  #           for (var k = 0; k < inputs.arrayTwoDim[i].length; k++) {
+  #             newArray.push((inputs.arrayTwoDim[i])[k]);
+  #           }
+  #         }
+  #         return { 'array_1d' : newArray }
+  #       }
+  #   in: 
+  #     arrayTwoDim: time_series/remaped_time_series
+  #   out:
+  #     [array_1d]

--- a/scripts/cwl_workflows/lnd-elm/ncremap_lnd.cwl
+++ b/scripts/cwl_workflows/lnd-elm/ncremap_lnd.cwl
@@ -1,0 +1,52 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+requirements:
+  - class: InlineJavascriptRequirement
+baseCommand: [srun]
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - ncremap
+  - -P
+  - "elm"
+  - -s
+  - $(inputs.source_grid)
+  - --sgs_frc=$(inputs.one_land_file)/landfrac
+  - -g
+  - $(inputs.destination_grid)
+  - -v
+  - $(inputs.var_list.join(','))
+
+inputs:
+  source_grid:
+    type: string
+  destination_grid:
+    type: string
+  lnd_files:
+    type: File
+  account:
+    type: string
+  partition:
+    type: string
+  timeout:
+    type: string
+  var_list:
+    type: string[]
+  one_land_file:
+    type: string
+
+stdin: $(inputs.lnd_files.path)
+
+
+outputs:
+  remaped_lnd_files:
+    type: File[]
+    outputBinding:
+      glob: 
+        - "*.nc"

--- a/scripts/cwl_workflows/lnd-elm/time_series_lnd.cwl
+++ b/scripts/cwl_workflows/lnd-elm/time_series_lnd.cwl
@@ -1,0 +1,60 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [srun]
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  variable_name:
+    type: string[]
+  start_year:
+    type: int
+  end_year:
+    type: int
+  year_per_file:
+    type: int
+  casename:
+    type: string
+  remapped_lnd_files:
+    type: File[]
+  account:
+    type: string
+  partition:
+    type: string
+  timeout:
+    type: string
+
+arguments:
+  - -A
+  - $(inputs.account)
+  - --partition
+  - $(inputs.partition)
+  - -t
+  - $(inputs.timeout)
+  - ncclimo
+  - "-7"
+  - --dfl_lvl=1
+  - --no_cll_msr
+  - -a
+  - sdd
+  - -P
+  - "elm"
+  - -v
+  - $(inputs.variable_name.join(' ')) 
+  - -c
+  - $(inputs.casename)
+  - -s
+  - $(inputs.start_year)
+  - -e
+  - $(inputs.end_year)
+  - $('--ypf='+inputs.year_per_file)
+  - --no_stdin
+  - $(inputs.remapped_lnd_files.map(function(el){return el.path}))
+
+outputs:
+  remaped_time_series:
+    type: File[]
+    outputBinding:
+      glob: 
+        - $("*_" + inputs.start_year.toString().padStart(4, "0") + "01_" + inputs.end_year.toString().padStart(4, "0") + "12.nc")


### PR DESCRIPTION
Example use (assuming e3sm_to_cmip repo is under one's home directory on LCRC: 

export TMPDIR=/lcrc/globalscratch/ac.zhang40/tmp (setting tmp directory is not required on LCRC)

# A /CIMP6 folder will generated where the commands are being issued.
cd /lcrc/group/e3sm/ac.zhang40/

# Command to generate land cmorized data
cwltool --tmpdir-prefix=$TMPDIR ~/e3sm_to_cmip/scripts/cwl_workflows/lnd-elm/lnd.cwl ~/e3sm_to_cmip/scripts/cwl_workflows/lnd-elm/lnd-job.yaml

# Command to generate atmosphere 2D and 3D cmorized data
cwltool --tmpdir-prefix=$TMPDIR ~/e3sm_to_cmip/scripts/cwl_workflows/atm-unified-eam/atm-unified.cwl ~/e3sm_to_cmip/scripts/cwl_workflows/atm-unified-eam/atm-unified-job.yaml

# Command to generate daily cmorized data
cwltool --tmpdir-prefix=$TMPDIR --preserve-environment UDUNITS2_XML_PATH ~/e3sm_to_cmip/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq.cwl ~/e3sm_to_cmip/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-day.yaml

# Command to generate 3hrly cmorized data
cwltool --tmpdir-prefix=$TMPDIR --preserve-environment UDUNITS2_XML_PATH ~/e3sm_to_cmip/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq.cwl ~/e3sm_to_cmip/scripts/cwl_workflows/atm-highfreq-eam/atm-highfreq-job-3hr.yaml

A /CIMP6 folder will generated where the commands are being issued.