### PR TITLE
fix time invariant daily rlut

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
+++ b/e3sm_to_cmip/cmor_handlers/rlut_highfreq.py
@@ -14,8 +14,8 @@ VAR_UNITS = str('W m-2')
 TABLE = str('CMIP6_day.json')
 POSITIVE = str('up')
 
-def write_data(varid, data, timeval, timebnds, **kwargs):
-    outdata = data["FLUT"].values
+def write_data(varid, data, timeval, timebnds, index, **kwargs):
+    outdata = data["FLUT"][index, :].values
     if kwargs.get('simple'):
         return outdata
     cmor.write(


### PR DESCRIPTION
This PR fixes time invariant daily rlut (i.e., files in /p/user_pub/work/CMIP6/CMIP/E3SM-Project/E3SM-1-0/historical/r1i1p1f1/day/rlut/gr/v20210910). 
An example output can be found on acme1:/p/user_pub/e3sm/zhang40/tests/rlut_day_E3SM-1-0_historical_r1i1p1f1_gr_18500101-18591231.nc

All daily rlut files need to be republished.

