### PR TITLE
Avoid NaNf as missing value

### DIFF
--- a/e3sm_to_cmip/default.py
+++ b/e3sm_to_cmip/default.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from e3sm_to_cmip.lib import handle_variables
 import cmor
-import xarray as xr
 import numpy as np
 
 

--- a/e3sm_to_cmip/default.py
+++ b/e3sm_to_cmip/default.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from e3sm_to_cmip.lib import handle_variables
 import cmor
+import xarray as xr
+import numpy as np
 
 
 def default_handler(infiles, tables, user_input_path, **kwargs):
@@ -41,6 +43,8 @@ def default_handler(infiles, tables, user_input_path, **kwargs):
             else:
                 outdata = data[RAW_VARIABLES[0]].values
 
+        outdata[np.isnan(outdata)] = 1e20 
+
         if kwargs.get('simple'):
             return outdata
 
@@ -52,6 +56,7 @@ def default_handler(infiles, tables, user_input_path, **kwargs):
                 time_bnds=timebnds)
         else:
             cmor.write(varid, outdata)
+        
         return outdata
 
     return handle_variables(


### PR DESCRIPTION
@TonyB9000 reported that in newer version of cmorized data, “Not-a-Number (float)” are presented as ‘NaNf’, while old version has `-` for missing values. Example:
>> Old version:
>> 
>>       _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
>> _, _, _,
>> 
>>       _, _, _, 2.037439e-05, 2.300697e-05, 2.66528e-05, _, _, _, _,
>> _, _, _, _,
>> 
>>       _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
>> _, _, _,
>> 
>> New Version:
>> 
>>       NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf,
>> NaNf, NaNf,
>> 
>>       NaNf, NaNf, NaNf, NaNf, 2.037439e-08, 2.300698e-08,
>> 2.665283e-08, NaNf,
>> 
>>       NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf, NaNf,
>> NaNf, NaNf,
>> 
>> Why are “Not-a-Number (float)” presented as ‘_’ for one file, and as
>> ‘NaNf’ for another?

This behavior turned out to be a side effect from converting to `xarray` from `cdms2`. In xarray, missing values are represented by NaN. This PR assigns fill_value= 1e20 to replace with NaNfs in output data (`outdata`). A resulted sample file can be found on acme1: /home/zhang40/tests/CMIP6/CMIP/E3SM-Project/E3SM-1-1/historical/r1i1p1f1/Lmon/ra/gr/v20220104/ra_Lmon_E3SM-1-1_historical_r1i1p1f1_gr_185001-187412.nc. 
The per variable time-series file is located at:/home/zhang40/tests/AR_185001_187412.nc
(some additional information: https://xarray.pydata.org/en/stable/user-guide/io.html.)