### PR TITLE
Access land var xarray objects using `.values` and fix `NaNf`

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/cLitter.py
+++ b/e3sm_to_cmip/cmor_handlers/cLitter.py
@@ -1,9 +1,12 @@
 """
 cLitter = (TOTLITC + CWDC)/1000.0
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import cmor
+import numpy as np
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -17,6 +20,8 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     cLitter = (TOTLITC + CWDC)/1000.0
     """
     outdata = (data['TOTLITC'][index, :] + data['CWDC'][index, :])/1000.0
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(

--- a/e3sm_to_cmip/cmor_handlers/cLitter.py
+++ b/e3sm_to_cmip/cmor_handlers/cLitter.py
@@ -19,7 +19,7 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     """
     cLitter = (TOTLITC + CWDC)/1000.0
     """
-    outdata = (data['TOTLITC'][index, :] + data['CWDC'][index, :])/1000.0
+    outdata = (data['TOTLITC'][index, :].values + data['CWDC'][index, :].values)/1000.0
     outdata[np.isnan(outdata)] = FILL_VALUE
 
     if kwargs.get('simple'):

--- a/e3sm_to_cmip/cmor_handlers/lai.py
+++ b/e3sm_to_cmip/cmor_handlers/lai.py
@@ -1,9 +1,12 @@
 """
 LAISHA, LAISUN to lai converter
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import cmor
+import numpy as np
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -18,6 +21,8 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     lai = LAISHA + LAISUN
     """
     outdata = data['LAISHA'][index, :].values + data['LAISUN'][index, :].values
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(

--- a/e3sm_to_cmip/cmor_handlers/mrfso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrfso.py
@@ -20,23 +20,17 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     """
     mrfso = verticalSum(SOILICE, capped_at=5000)
     """
+    soil_ice = data['SOILICE'][index, :].values
+
     # we only care about data with a value greater then 0
-    mask = np.greater(data['SOILICE'][index, :], 0.0)
+    mask = np.greater(soil_ice, 0.0)
 
     # sum the data over the levgrnd axis
-    outdata = np.sum(
-        data['SOILICE'][index, :].values,
-        axis=0)
+    outdata = np.sum(soil_ice, axis=0)
 
     # replace all values greater then 5k with 5k
-    capped = np.where(
-        np.greater(outdata, 5000.0),
-        5000.0,
-        outdata)
-    outdata = np.where(
-        mask,
-        capped,
-        outdata)
+    capped = np.where(np.greater(outdata, 5000.0), 5000.0, outdata)
+    outdata = np.where(mask, capped, outdata)
     outdata[np.isnan(outdata)] = FILL_VALUE
 
     if kwargs.get('simple'):

--- a/e3sm_to_cmip/cmor_handlers/mrfso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrfso.py
@@ -1,12 +1,12 @@
 """
 SOILICE to mrfso converter
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import cmor
-import logging
 import numpy as np
-
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -37,6 +37,8 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
         mask,
         capped,
         outdata)
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(

--- a/e3sm_to_cmip/cmor_handlers/mrfso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrfso.py
@@ -25,7 +25,7 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
 
     # sum the data over the levgrnd axis
     outdata = np.sum(
-        data['SOILICE'][index, :],
+        data['SOILICE'][index, :].values,
         axis=0)
 
     # replace all values greater then 5k with 5k

--- a/e3sm_to_cmip/cmor_handlers/mrso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrso.py
@@ -20,21 +20,16 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     """
     mrso = verticalSum(SOILICE + SOILLIQ, capped_at=5000)
     """
-    icemask = np.greater(data['SOILICE'][index, :], 0.0)
-    liqmask = np.greater(data['SOILLIQ'][index, :], 0.0)
+    soil_ice = data['SOILICE'][index, :].values
+    soil_liq = data['SOILLIQ'][index, :].values
+
+    icemask = np.greater(soil_ice, 0.0)
+    liqmask = np.greater(soil_liq, 0.0)
     total_mask = np.logical_or(icemask, liqmask)
 
-    outdata = np.sum(
-        data['SOILICE'][index, :].values + data['SOILLIQ'][index, :].values,
-        axis=0)
-    capped = np.where(
-        np.greater(outdata, 5000.0),
-        5000.0,
-        outdata)
-    outdata = np.where(
-        total_mask,
-        capped,
-        outdata)
+    outdata = np.sum(soil_ice + soil_liq, axis=0)
+    capped = np.where(np.greater(outdata, 5000.0), 5000.0, outdata)
+    outdata = np.where(total_mask, capped, outdata)
     outdata[np.isnan(outdata)] = FILL_VALUE
 
     if kwargs.get('simple'):

--- a/e3sm_to_cmip/cmor_handlers/mrso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrso.py
@@ -25,7 +25,7 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     total_mask = np.logical_or(icemask, liqmask)
 
     outdata = np.sum(
-        data['SOILICE'][index, :] + data['SOILLIQ'][index, :],
+        data['SOILICE'][index, :].values + data['SOILLIQ'][index, :].values,
         axis=0)
     capped = np.where(
         np.greater(outdata, 5000.0),

--- a/e3sm_to_cmip/cmor_handlers/mrso.py
+++ b/e3sm_to_cmip/cmor_handlers/mrso.py
@@ -1,13 +1,12 @@
 """
 SOILICE, SOILIQ to mrso converter
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
-import os
 import cmor
-import logging
 import numpy as np
-
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -36,6 +35,8 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
         total_mask,
         capped,
         outdata)
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(

--- a/e3sm_to_cmip/cmor_handlers/tran.py
+++ b/e3sm_to_cmip/cmor_handlers/tran.py
@@ -1,9 +1,12 @@
 """
 QVEGT, QSOIL to tran converter
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import cmor
+import numpy as np
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -18,6 +21,8 @@ def write_data(varid, data, timeval, timebnds, index, **kwargs):
     tran = QSOIL + QVEGT
     """
     outdata = data['QVEGT'][index, :].values + data['QSOIL'][index, :].values
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(

--- a/e3sm_to_cmip/cmor_handlers/tsl.py
+++ b/e3sm_to_cmip/cmor_handlers/tsl.py
@@ -5,6 +5,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import cmor
+import numpy as np
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.lib import handle_variables
 
 # list of raw variable names needed
@@ -22,6 +24,8 @@ LEVELS = {
 
 def write_data(varid, data, timeval, timebnds, index, **kwargs):
     outdata = data['TSOI'][index, :].values
+    outdata[np.isnan(outdata)] = FILL_VALUE
+
     if kwargs.get('simple'):
         return outdata
     cmor.write(


### PR DESCRIPTION
- Closes #107 

Adds fill value for land variable handlers 1-12 in this list: https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/925500501/Lmon+variable+conversion+table

Land variables fixed

1. `cLitter`
2. `lai`
3. `mrfso`
4. `mrso`
5. `tran`
6. `tsl`

Default land vars already fixed (through `default.py`):

1. `mrsos`
2. `mrros`
3. `mrro`
4. `prveg`
5. `evspsblveg`
6. `evspsblsoi`