### PR TITLE
Update dependencies in `ci.yml` and `dev.yml`

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -61,6 +61,11 @@ jobs:
         run: |
           python -m pip install .
 
+      # TODO: Add test suite and enable this
+      # - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+      #   name: Run Tests
+      #   run: pytest
+
   publish-docs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
@@ -95,7 +100,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==4.3.2 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4
+          pip install sphinx==4.4.0 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4
 
       - name: Build Sphinx Docs
         run: |

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==4.3.2 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4
+          pip install sphinx==4.4.0 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4
 
       - name: Build Sphinx Docs
         run: |

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -8,4 +8,19 @@ dependencies:
   # ==================
   - python>=3.8
   - pip
+  - nco
+  - cmor
+  - tqdm
+  - pyyaml
+  - xarray
+  - netcdf4
+  - dask
+  - scipy
+  # Used for phalf and pfull handlers.
+  # Note, these two packages don't support Python >3.8
+  - cdms2=3.1.5
+  - cdutil=8.2.1
+  # Testing
+  # ==================
+  - pytest
 prefix: /opt/miniconda3/envs/e3sm_to_cmip_ci

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -8,27 +8,30 @@ dependencies:
   # ==================
   - python=3.8.10
   - pip=21.2.4
-  - nco=4.9.9
+  - nco=5.0.6
   - cmor=3.6.1
-  - tqdm=4.62.0
-  - pyyaml=5.4.1
-  - xarray=0.19.0
-  - netcdf4=1.5.6
-  - dask=2021.7.2
-  - scipy=1.7.0
+  - tqdm=4.62.3
+  - pyyaml=6.0
+  - xarray=0.21.2
+  - netcdf4=1.5.8
+  - dask=2022.1.1
+  - scipy=1.7.3
   # Used for phalf and pfull handlers.
   # Note, these two packages don't support Python >3.8
   - cdms2=3.1.5
   - cdutil=8.2.1
+  # Testing
+  # ==================
+  - pytest=6.2.5
   # Documentation
   # =================
-  - sphinx=4.3.2
+  - sphinx=4.4.0
   - sphinx_rtd_theme=1.0.0
-  - tbump==6.7.0
+  - tbump=6.7.0
     # CWL
   # ==================
-  - cwltool=3.1.20210816212154
-  - nodejs=16.6.1
+  - cwltool=3.1.20220202173120
+  - nodejs=17.4.0
   - pip:
       - sphinx-multiversion==0.2.4
 prefix: /opt/miniconda3/envs/e3sm_to_cmip_dev


### PR DESCRIPTION
- Closes #116 

Additional Info
- `ci.yml` requires the same base dependencies specified in the conda-forge feedstock when building the local package using `pip` for testing in the CI/CD build workflow
- Update sphinx versions in workflows