### PR TITLE
Elide cwl logging

### DIFF
--- a/scripts/cwl_workflows/atm-mon-model-lev/atm-std.cwl
+++ b/scripts/cwl_workflows/atm-mon-model-lev/atm-std.cwl
@@ -30,10 +30,6 @@ outputs:
     type: Directory[]
     outputSource: 
       - step_std_cmor/cmip6_dir
-  # logs:
-  #   type: Directory[]
-  #   outputSource:
-  #     - step_std_cmor/cmor_logs
 
 steps:
   step_find_casename:
@@ -121,4 +117,3 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-      # - cmor_logs

--- a/scripts/cwl_workflows/atm-mon-model-lev/cmor.cwl
+++ b/scripts/cwl_workflows/atm-mon-model-lev/cmor.cwl
@@ -51,7 +51,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  # cmor_logs:
-  #   type: Directory
-  #   outputBinding:
-  #     glob: cmor_logs

--- a/scripts/cwl_workflows/atm-mon-plev/atm-plev.cwl
+++ b/scripts/cwl_workflows/atm-mon-plev/atm-plev.cwl
@@ -32,11 +32,6 @@ outputs:
     outputSource: 
       - step_plev_cmor/cmip6_dir
     linkMerge: merge_flattened
-#  logs:
-#    type: Directory[]
-#    outputSource:
-#     - step_plev_cmor/cmor_logs
-#  linkMerge: merge_flattened
 
 steps:
   step_find_casename:
@@ -139,4 +134,3 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-#      - cmor_logs

--- a/scripts/cwl_workflows/atm-mon-plev/cmor.cwl
+++ b/scripts/cwl_workflows/atm-mon-plev/cmor.cwl
@@ -51,7 +51,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-# cmor_logs:
-#   type: Directory
-#   outputBinding:
-#     glob: cmor_logs

--- a/scripts/cwl_workflows/atm-unified-eam/atm-unified.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/atm-unified.cwl
@@ -36,12 +36,6 @@ outputs:
       - step_std_cmor/cmip6_dir
       - step_plev_cmor/cmip6_dir
     linkMerge: merge_flattened
-  # logs:
-  #   type: Directory[]
-  #   outputSource:
-  #     - step_std_cmor/cmor_logs
-  #     - step_plev_cmor/cmor_logs
-  #   linkMerge: merge_flattened
 
 steps:
   step_find_casename:
@@ -129,7 +123,6 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-#      - cmor_logs
 
   step_vrt_remap:
     run: vrtremap.cwl
@@ -183,4 +176,3 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-      # - cmor_logs

--- a/scripts/cwl_workflows/atm-unified-eam/cmor.cwl
+++ b/scripts/cwl_workflows/atm-unified-eam/cmor.cwl
@@ -51,7 +51,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  # cmor_logs:
-  #   type: Directory
-  #   outputBinding:
-  #     glob: cmor_logs

--- a/scripts/cwl_workflows/atm-unified/atm-unified.cwl
+++ b/scripts/cwl_workflows/atm-unified/atm-unified.cwl
@@ -36,12 +36,6 @@ outputs:
       - step_std_cmor/cmip6_dir
       - step_plev_cmor/cmip6_dir
     linkMerge: merge_flattened
-  # logs:
-  #   type: Directory[]
-  #   outputSource:
-  #     - step_std_cmor/cmor_logs
-  #     - step_plev_cmor/cmor_logs
-  #   linkMerge: merge_flattened
 
 steps:
   step_find_casename:
@@ -129,7 +123,6 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-#      - cmor_logs
 
   step_vrt_remap:
     run: vrtremap.cwl
@@ -183,4 +176,3 @@ steps:
       timeout: timeout
     out:
       - cmip6_dir
-      # - cmor_logs

--- a/scripts/cwl_workflows/atm-unified/cmor.cwl
+++ b/scripts/cwl_workflows/atm-unified/cmor.cwl
@@ -51,7 +51,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  # cmor_logs:
-  #   type: Directory
-  #   outputBinding:
-  #     glob: cmor_logs

--- a/scripts/cwl_workflows/lnd-elm/cmor.cwl
+++ b/scripts/cwl_workflows/lnd-elm/cmor.cwl
@@ -54,7 +54,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  # logs:
-  #   type: Directory
-  #   outputBinding:
-  #     glob: cmor_logs

--- a/scripts/cwl_workflows/lnd-elm/lnd.cwl
+++ b/scripts/cwl_workflows/lnd-elm/lnd.cwl
@@ -32,12 +32,6 @@ outputs:
     type: Directory[]
     outputSource: step_cmor/cmip6_dir
     linkMerge: merge_flattened
-  # cmor_logs:
-  #   type: Directory[]
-  #   outputSource: step_cmor/logs
-  # time_series:
-  #   type: File[]
-  #   outputSource: step_join_timeseries/array_1d
 
 steps:
 
@@ -134,7 +128,6 @@ steps:
       - raw_file_list
     out:
       - cmip6_dir
-      # - logs
   
   # step_join_timeseries:
   #   run:

--- a/scripts/cwl_workflows/lnd-n2n/cmor.cwl
+++ b/scripts/cwl_workflows/lnd-n2n/cmor.cwl
@@ -54,7 +54,3 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  # logs:
-  #   type: Directory
-  #   outputBinding:
-  #     glob: cmor_logs

--- a/scripts/cwl_workflows/lnd-n2n/lnd.cwl
+++ b/scripts/cwl_workflows/lnd-n2n/lnd.cwl
@@ -32,12 +32,6 @@ outputs:
     type: Directory[]
     outputSource: step_cmor/cmip6_dir
     linkMerge: merge_flattened
-  # cmor_logs:
-  #   type: Directory[]
-  #   outputSource: step_cmor/logs
-  # time_series:
-  #   type: File[]
-  #   outputSource: step_join_timeseries/array_1d
 
 steps:
 
@@ -134,7 +128,6 @@ steps:
       - raw_file_list
     out:
       - cmip6_dir
-      # - logs
   
   # step_join_timeseries:
   #   run:

--- a/scripts/cwl_workflows/mpaso-atm/mpaso_sbatch_render.cwl
+++ b/scripts/cwl_workflows/mpaso-atm/mpaso_sbatch_render.cwl
@@ -19,7 +19,6 @@ requirements:
               e3sm_to_cmip \
                   -s \
                   --realm mpaso \
-                  --precheck {{ workflow_output }} \
                   -v {{ variables }} \
                   --tables-path {{ tables }} \
                   --user-metadata {{ metadata }} \

--- a/scripts/cwl_workflows/mpaso/mpaso.cwl
+++ b/scripts/cwl_workflows/mpaso/mpaso.cwl
@@ -74,7 +74,3 @@ outputs:
     type: 
       Directory[]
     outputSource: step_render_cmor_template/cmorized
-  # logs:
-  #   type:
-  #     Directory[]
-  #   outputSource: step_render_cmor_template/logs

--- a/scripts/cwl_workflows/mpaso/mpaso.cwl
+++ b/scripts/cwl_workflows/mpaso/mpaso.cwl
@@ -67,7 +67,6 @@ steps:
       flat_crossproduct
     out:
       - cmorized
-    #   - logs
 
 outputs: 
   cmorized:

--- a/scripts/cwl_workflows/mpaso/mpaso_sbatch_render.cwl
+++ b/scripts/cwl_workflows/mpaso/mpaso_sbatch_render.cwl
@@ -19,7 +19,6 @@ requirements:
               e3sm_to_cmip \
                   -s \
                   --realm mpaso \
-                  --precheck {{ workflow_output }} \
                   -v {{ variables }} \
                   --tables-path {{ tables }} \
                   --user-metadata {{ metadata }} \

--- a/scripts/cwl_workflows/mpaso/mpaso_sbatch_render.cwl
+++ b/scripts/cwl_workflows/mpaso/mpaso_sbatch_render.cwl
@@ -118,10 +118,6 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  logs:
-    type: Directory
-    outputBinding:
-      glob: cmor_logs
 
 arguments:
   - --outdir

--- a/scripts/cwl_workflows/mpassi/mpassi.cwl
+++ b/scripts/cwl_workflows/mpassi/mpassi.cwl
@@ -63,7 +63,6 @@ steps:
       nested_crossproduct
     out:
       - cmorized
-    #  - cmor_logs
 
 outputs:
   cmorized:
@@ -73,11 +72,3 @@ outputs:
         type: array
         items: Directory
     outputSource: step_cmor/cmorized
-  # logs:
-  #   type:
-  #     type: array
-  #     items:
-  #       type: array
-  #       items: Directory
-  #   outputSource:
-  #     step_cmor/cmor_logs

--- a/scripts/cwl_workflows/mpassi/mpassi_cmor.cwl
+++ b/scripts/cwl_workflows/mpassi/mpassi_cmor.cwl
@@ -40,7 +40,6 @@ arguments:
   - $(inputs.timeout)
   - e3sm_to_cmip
   - -s
-  - --precheck
   - --output-path
   - $(runtime.outdir)
   - --realm

--- a/scripts/cwl_workflows/mpassi/mpassi_srun_render_cmor.cwl
+++ b/scripts/cwl_workflows/mpassi/mpassi_srun_render_cmor.cwl
@@ -19,7 +19,6 @@ requirements:
               e3sm_to_cmip \
                   -s \
                   --realm mpassi \
-                  --precheck {{ workflow_output }} \
                   -v {{ variables }} \
                   --tables-path {{ tables }} \
                   --user-metadata {{ metadata }} \

--- a/scripts/cwl_workflows/mpassi/mpassi_srun_render_cmor.cwl
+++ b/scripts/cwl_workflows/mpassi/mpassi_srun_render_cmor.cwl
@@ -116,10 +116,6 @@ outputs:
     type: Directory
     outputBinding:
       glob: CMIP6
-  cmor_logs:
-    type: Directory
-    outputBinding:
-      glob: cmor_logs
 
 arguments:
   - --outdir


### PR DESCRIPTION
At Tom's suggestion, I removed all of the "commented-out" logging lines.  I believe Sterling had discovered problems with retrieving cwltool cmor logs, perhaps due to temp-file/directory issues, that would cause whole workflows to fail.  I also eliminated 4 instances of "--precheck" on the command lines, until we can ascertain how to make that functionality cognizant of variant-label.  Presently, the precheck would cause realization_index > 1 to fail, if realization_index 1 data were present, thinking that the data was already generated.