### PR TITLE
Fix codecov report

### DIFF
--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -16,8 +16,7 @@ import xarray as xr
 import yaml
 from tqdm import tqdm
 
-from e3sm_to_cmip import __version__  # pragma: no cover
-from e3sm_to_cmip import resources
+from e3sm_to_cmip import __version__, resources
 from e3sm_to_cmip._logger import _setup_custom_logger
 
 logger = _setup_custom_logger(__name__)


### PR DESCRIPTION
There was a a drop in the codecov from the latest `master` commit (https://codecov.io/gh/E3SM-Project/e3sm_to_cmip/commit/e6e0a014357c47f854f81fb75820fe3cdb980a03/).