### PR TITLE
Separate mask retreval for MPASO and MPASSI masks

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/areacello.py
@@ -48,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
     earth_radius = dsMesh.attrs['sphere_radius']
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     ds = xarray.Dataset()
     ds[VAR_NAME] = ('nCells', cellMask2D.astype(float))

--- a/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/hfsifrazil.py
@@ -57,7 +57,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         float(namelist['config_frazil_heat_of_fusion'])
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_frazilLayerThicknessTendency',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/masscello.py
@@ -56,7 +56,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     config_density0 = float(namelist['config_density0'])
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/masso.py
@@ -55,7 +55,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     config_density0 = float(namelist['config_density0'])
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mlotst.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_dThreshMLD',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/pbo.py
@@ -59,7 +59,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     gravity = 9.80616
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, cellMask3D = mpas.get_cell_masks(dsMesh)
+    cellMask2D, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_pressureAdjustedSSH',
                     'timeMonthly_avg_ssh', 'timeMonthly_avg_layerThickness',

--- a/e3sm_to_cmip/cmor_handlers/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/pso.py
@@ -58,7 +58,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     gravity = 9.80616
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, cellMask3D = mpas.get_cell_masks(dsMesh)
+    cellMask2D, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_pressureAdjustedSSH',
                     'timeMonthly_avg_ssh', 'timeMonthly_avg_layerThickness',

--- a/e3sm_to_cmip/cmor_handlers/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/siconc.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/simass.py
@@ -50,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     rhoi = 917.0
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_iceVolumeCell',

--- a/e3sm_to_cmip/cmor_handlers/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnmass.py
@@ -55,7 +55,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     rhos = 330.0
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_snowVolumeCell',

--- a/e3sm_to_cmip/cmor_handlers/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/sisnthick.py
@@ -53,7 +53,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_snowVolumeCell',

--- a/e3sm_to_cmip/cmor_handlers/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/sitemptop.py
@@ -53,7 +53,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_surfaceTemperatureCell',

--- a/e3sm_to_cmip/cmor_handlers/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/sithick.py
@@ -53,7 +53,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_iceVolumeCell',

--- a/e3sm_to_cmip/cmor_handlers/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/sitimefrac.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_icePresent', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/siu.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_uVelocityGeo', 'xtime_startMonthly',

--- a/e3sm_to_cmip/cmor_handlers/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/siv.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASSI']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D = mpas.get_mpassi_cell_mask(dsMesh)
 
     variableList = ['timeMonthly_avg_iceAreaCell',
                     'timeMonthly_avg_vVelocityGeo', 'xtime_startMonthly',

--- a/e3sm_to_cmip/cmor_handlers/so.py
+++ b/e3sm_to_cmip/cmor_handlers/so.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_salinity',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/sob.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_salinity',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/soga.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness',
                     'timeMonthly_avg_activeTracers_salinity',

--- a/e3sm_to_cmip/cmor_handlers/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/sos.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_salinity',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/sosga.py
@@ -50,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_salinity',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/thetao.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_temperature',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/thetaoga.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness',
                     'timeMonthly_avg_activeTracers_temperature',

--- a/e3sm_to_cmip/cmor_handlers/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/thkcello.py
@@ -50,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/tob.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_temperature',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/tos.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_temperature',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/tosga.py
@@ -50,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_activeTracers_temperature',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/uo.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_velocityZonal',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/vo.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_velocityMeridional',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/volcello.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
     earth_radius = dsMesh.attrs['sphere_radius']
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/volo.py
@@ -51,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness', 'xtime_startMonthly',
                     'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/wo.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_vertVelocityTop',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/zhalfo.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    _, cellMask3D = mpas.get_cell_masks(dsMesh)
+    _, cellMask3D = mpas.get_mpaso_cell_masks(dsMesh)
 
     variableList = ['timeMonthly_avg_layerThickness',
                     'xtime_startMonthly', 'xtime_endMonthly']

--- a/e3sm_to_cmip/cmor_handlers/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/zos.py
@@ -52,7 +52,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     timeSeriesFiles = infiles['MPASO']
 
     dsMesh = xarray.open_dataset(meshFileName, mask_and_scale=False)
-    cellMask2D, _ = mpas.get_cell_masks(dsMesh)
+    cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
     areaCell = dsMesh.areaCell.where(cellMask2D)
 
     variableList = ['timeMonthly_avg_pressureAdjustedSSH',

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -194,8 +194,8 @@ def add_si_mask(ds, mask, siconc, threshold=0.05):
     return ds
 
 
-def get_cell_masks(dsMesh):
-    '''Get 2D and 3D masks of valid MPAS cells from the mesh Dataset'''
+def get_mpaso_cell_masks(dsMesh):
+    '''Get 2D and 3D masks of valid MPAS-Ocean cells from the mesh Dataset'''
 
     cellMask2D = dsMesh.maxLevelCell > 0
 
@@ -208,6 +208,14 @@ def get_cell_masks(dsMesh):
     cellMask3D = vertIndex < dsMesh.maxLevelCell
 
     return cellMask2D, cellMask3D
+
+
+def get_mpassi_cell_mask(dsMesh):
+    '''Get 2D mask of valid MPAS-Seaice cells from the mesh Dataset'''
+
+    cellMask2D = xarray.ones_like(dsMesh.xCell)
+
+    return cellMask2D
 
 
 def get_sea_floor_values(ds, dsMesh):


### PR DESCRIPTION
The MPAS-Seaice restart files don't include the maxLevelCell variable that is used in MPAS-Ocean to determine the 2D cell mask, and certainly don't include the information needed to determine the 3D mask (which only applies to the ocean).  As a result, it makes sense to have different masks for the 2 components.