### PR TITLE
Remain time as record dimension as raw data and include --no_permute 

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -84,7 +84,7 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
     if "depth" in ds.dims:
         ds = ds.transpose("time", "depth", "nCells", "nbnd")
 
-    write_netcdf(ds, inFileName)
+    write_netcdf(ds, inFileName, unlimited = "time")
 
     # set an environment variable to make sure we're not using czender's
     # local version of NCO instead of one we have intentionally loaded

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -106,6 +106,7 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
             "--no_stdin",
             "--no_cll_msr",
             "--no_frm_trm",
+            "--no_permute",
             f"--map={mappingFileName}",
             inFileName,
             outFileName,


### PR DESCRIPTION
This PR bring back time as record dimension as in raw data before calling ncremap for mpas data regridding.
@TonyB9000 reported chunk size error when processing a 3d variable `zhalfo` with >2 years per chunk. Error message:
```
"nco_def_var_chunking(): ERROR Total requested chunk size = 6935055840
 exceeds netCDF maximium-supported chunk size = 4294967295"
```

Notes from @czender: Cause of ncremap's "chunk size" error:
When processing ocean fields of roughly the same size as
we used in the v1 CMIP datasets, the new v2 workflow fails
when the ncremap regridder step throws a "chunk size" error.
This new occurs because the intermediate files that ncremap
is asked to regrid contain "time" as a fixed (not record) dimension.
"Time" is a record variable in the raw MPAS v2 data.
The property is lost somewhere in the intervening v2 workflow
and (the renamed) "time" dimension emerges as fixed (not record).
The chain of cause and effect is subtle, and it's perhaps better
to just summarize that this causes the "chunksize" used by
the (CMIP-required) compression to receive a chunksize that
is greater than it used to be (in the v2 raw data and v1 workflow)
by a factor equal to the number of timesteps stored.
For a 10-year (120 month) MPAS ocean timeseries this factor is 120.
Again, I suggest someone investigate where in the v2 workflow
the time dimension is converted from a record to a fixed dimension,
and eliminate that.

Potential workarounds to ncremap's "chunk size" error:
1. Invoke ncremap with the --no_permute flag (see documentation).
This is not recommended since it does not fix the record dimension issue,
though it does allow larger (to a point) timeseries to be regridded.
2. Invoke ncremap with additional options (to ncpdq) that convert
time to a record dimension of chunksize 1. This could be done in the
short-term, or if it's too late to fix the underlying problem before
E3SMU-1.8. The new invocation would look something like
ncremap --pdq_opt='-a time,olevhalf,olev,nCells -U --cnk_dmn time,1' ...
Again, this is sub-optimal relative to preserving the record
characteristic of the time dimension throughout the v2 workflow.
However, it will work for datasets of any size.
3. Alternative number 2 option to turn time into a record dimension.
Invoke ncremap with an option like this to fix the record dimension issue:
ncremap --nco_opt='--mk_rec_dmn time'
Again, should work for all sizes though not recommended relative to
fixing the problem upstream.