### PR TITLE
Bump conda env dependencies

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -33,11 +33,11 @@ jobs:
           do_not_skip: '["push", "workflow_dispatch"]'
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Cache Conda
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if conda-env/ci.yml has not changed in the workflow
           CACHE_NUMBER: 0
@@ -68,7 +68,7 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: "tests_coverage_reports/coverage.xml"
           fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,9 @@ repos:
         additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.941
+    rev: v0.991
     hooks:
       - id: mypy
         args: ["--config=setup.cfg"]
         additional_dependencies:
-          [dask==2022.3.0, numpy==1.22.3, xarray==2022.3.0]
+          [dask==2022.11.1, numpy==1.23.5, xarray==2022.11.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
 
@@ -23,7 +23,7 @@ repos:
   # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
   # https://github.com/pre-commit/pre-commit/issues/1206
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -8,13 +8,14 @@ dependencies:
   # ==================
   - python>=3.9
   - pip
-  - nco
   - cmor>=3.6.0
-  - tqdm
-  - pyyaml
-  - xarray
-  - netcdf4
   - dask
+  - nco
+  - netcdf4
+  - numpy
+  - pyyaml
+  - tqdm
+  - xarray
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   # Base
   # ==================
-  - python>=3.8
+  - python>=3.9
   - pip
   - nco
   - cmor>=3.6.0
@@ -15,13 +15,9 @@ dependencies:
   - xarray
   - netcdf4
   - dask
-  - scipy
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1
-  # Required for CWL workflows.
-  - cwltool
-  - nodejs
   # Testing
   # ==================
   - pytest

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -31,6 +31,7 @@ dependencies:
   - isort=5.10.1
   - mypy=0.991
   - pre-commit=2.20.0
+  - types-PyYAML=6.0.11
   # Testing
   # ==================
   - pytest=7.2.0

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -8,13 +8,14 @@ dependencies:
   # ==================
   - python=3.10.8
   - pip=22.3.1
-  - nco=5.1.3
   - cmor=3.7.0
-  - tqdm=4.64.1
-  - pyyaml=6.0
-  - xarray=2022.11.0
-  - netcdf4=1.6.2
   - dask=2022.11.1
+  - nco=5.1.3
+  - netcdf4=1.6.2
+  - numpy=1.23.5
+  - pyyaml=6.0
+  - tqdm=4.64.1
+  - xarray=2022.11.0
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -6,35 +6,34 @@ channels:
 dependencies:
   # Base
   # ==================
-  - python=3.9.13
-  - pip=21.2.4
-  - nco=5.1.1
+  - python=3.10.8
+  - pip=22.3.1
+  - nco=5.1.3
   - cmor=3.7.0
   - tqdm=4.64.1
   - pyyaml=6.0
-  - xarray=2022.10.0
-  - netcdf4=1.6.1
-  - dask=2022.10.2
-  - scipy=1.9.3
+  - xarray=2022.11.0
+  - netcdf4=1.6.2
+  - dask=2022.11.1
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1
   # Required for CWL workflows.
-  - cwltool=3.1.20220202173120
-  - nodejs=17.4.0
+  - cwltool=3.1.20221109155812
+  - nodejs=18.12.1
   # Quality Assurance
   # ==================
   # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`
-  - black=22.3.0
-  - flake8=4.0.1
-  - flake8-isort=4.1.1
+  - black=22.10.0
+  - flake8=6.0.0
+  - flake8-isort=5.0.3
   - isort=5.10.1
-  - mypy=0.941
-  - pre-commit=2.17.0
+  - mypy=0.991
+  - pre-commit=2.20.0
   # Testing
   # ==================
-  - pytest=7.1.1
-  - pytest-cov=3.0.0
+  - pytest=7.2.0
+  - pytest-cov=4.0.0
   # Documentation
   # =================
   - sphinx=4.4.0

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -6,22 +6,18 @@ channels:
 dependencies:
   # Base
   # ==================
-  - python=3.9.10
-  - pip=21.2.4
-  - nco=5.0.6
-  - cmor=3.6.1
-  - tqdm=4.62.3
+  - python=3.10.8
+  - pip=22.3.1
+  - nco=5.1.3
+  - cmor=3.7.0
+  - tqdm=4.64.1
   - pyyaml=6.0
-  - xarray=0.21.1
-  - netcdf4=1.5.8
-  - dask=2022.1.1
-  - scipy=1.7.3
+  - xarray=2022.11.0
+  - netcdf4=1.6.2
+  - dask=2022.11.1
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1
-  # Required for CWL workflows.
-  - cwltool=3.1.20220202173120
-  - nodejs=17.4.0
   # Documentation
   # =================
   - sphinx=4.4.0

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -8,13 +8,14 @@ dependencies:
   # ==================
   - python=3.10.8
   - pip=22.3.1
-  - nco=5.1.3
   - cmor=3.7.0
-  - tqdm=4.64.1
-  - pyyaml=6.0
-  - xarray=2022.11.0
-  - netcdf4=1.6.2
   - dask=2022.11.1
+  - nco=5.1.3
+  - netcdf4=1.6.2
+  - numpy=1.23.5
+  - pyyaml=6.0
+  - tqdm=4.64.1
+  - xarray=2022.11.0
   # Required for phalf and pfull handlers.
   - cdms2=3.1.5
   - cdutil=8.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,14 @@ exclude =
     *__init__.py
     venv
 
+[mypy]
+python_version = 3.10
+check_untyped_defs = True
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True
+
 [aliases]
 # Define setup.py command aliases here
 test = pytest


### PR DESCRIPTION
This PR bumps conda env dependencies and replaces/removes unnecessary dependencies. It also adds some configuration for `mypy`.

This PR was driven from some dependency conflict issues with `nco` and `libzlib`, but routine housecleaning should be performed anyways.