### PR TITLE
fix areacello in Ofx 

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/areacello.py
@@ -51,7 +51,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     cellMask2D, _ = mpas.get_mpaso_cell_masks(dsMesh)
 
     ds = xarray.Dataset()
-    ds[VAR_NAME] = ('nCells', cellMask2D.astype(float))
+    print(ds)
+    ds[VAR_NAME] = ('nCells', cellMask2D.astype(float).data)
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
     # the result above is just a mask of area fraction.  We need to multiply


### PR DESCRIPTION
Running e3sm_to_cmip to convert areacello from Ofx returns an error:
```
Using a DataArray object to construct a variable is ambiguous, please extract the data using the .data property.
```
This PR fixes this issue.