### PR TITLE
Update KeyError raised for missing handlers or non-derivable variables to logger warning

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -73,7 +73,7 @@ def load_all_handlers(
 
             handlers = handlers + var_handler
 
-        if len(missing_handlers) > 0:
+        if len(missing_handlers) == len(cmip_vars):
             raise KeyError(
                 f"No handlers are defined for the variables: {missing_handlers}. "
                 "Make sure at least one variable handler is defined for each of these "
@@ -115,7 +115,7 @@ def _get_mpas_handlers(cmip_vars: List[str]):
 
         derived_handlers.append(var_handler[0])
 
-    if len(missing_handlers) > 0:
+    if len(missing_handlers) == len(cimp_vars):
         raise KeyError(
             f"No variable handlers are defined for {missing_handlers}. Make sure at "
             "least one variable handler is defined for each of these variables in "
@@ -210,14 +210,14 @@ def derive_handlers(
 
         derived_handlers.append(derived_handler)
 
-    if len(missing_handlers) > 0:
+    if len(missing_handlers) == len(cmip_vars):
         raise KeyError(
             f"No handlers are defined for the variables: {missing_handlers}. "
             "Make sure handlers are defined for these variables in `handlers.yaml`."
         )
 
     if len(cannot_derive) > 0:
-        raise KeyError(
+        logger.info(
             f"No handlers could be derived for the variables: {cannot_derive}. "
             "Make sure the input E3SM datasets have the variables needed derivation."
         )

--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -73,8 +73,8 @@ def load_all_handlers(
 
             handlers = handlers + var_handler
 
-        if len(missing_handlers) == len(cmip_vars):
-            raise KeyError(
+        if len(missing_handlers) > 0:
+            logger.warning(
                 f"No handlers are defined for the variables: {missing_handlers}. "
                 "Make sure at least one variable handler is defined for each of these "
                 f"variables in `{HANDLER_DEFINITIONS_PATH}`."
@@ -115,8 +115,8 @@ def _get_mpas_handlers(cmip_vars: List[str]):
 
         derived_handlers.append(var_handler[0])
 
-    if len(missing_handlers) == len(cimp_vars):
-        raise KeyError(
+    if len(missing_handlers) > 0:
+        logger.warning(
             f"No variable handlers are defined for {missing_handlers}. Make sure at "
             "least one variable handler is defined for each of these variables in "
             f"`{MPAS_HANDLER_DIR_PATH}`."
@@ -210,14 +210,14 @@ def derive_handlers(
 
         derived_handlers.append(derived_handler)
 
-    if len(missing_handlers) == len(cmip_vars):
-        raise KeyError(
+    if len(missing_handlers) > 0:
+        logger.warning(
             f"No handlers are defined for the variables: {missing_handlers}. "
             "Make sure handlers are defined for these variables in `handlers.yaml`."
         )
 
     if len(cannot_derive) > 0:
-        logger.info(
+        logger.warning(
             f"No handlers could be derived for the variables: {cannot_derive}. "
             "Make sure the input E3SM datasets have the variables needed derivation."
         )

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -71,6 +71,8 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
     ds_out_all = ds_out_all.drop("timeMonthly_avg_iceAreaCell")
     ds_out_all.to_netcdf(outFileName)
 
+    shutil.rmtree(outFilePath, ignore_errors=True)
+
 
 def remap(ds, pcode, mappingFileName, threshold=0.0):
     """Use ncreamp to remap the xarray Dataset to a new target grid"""
@@ -127,6 +129,7 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
 
     # remove the temporary files
     os.remove(inFileName)
+    os.remove(outFileName)
 
     return ds
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -70,8 +70,9 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
     )
     ds_out_all = ds_out_all.drop("timeMonthly_avg_iceAreaCell")
     ds_out_all.to_netcdf(outFileName)
+    print('****',outFileName)
 
-    shutil.rmtree(outFilePath, ignore_errors=True)
+    #shutil.rmtree(outFilePath, ignore_errors=True)
 
 
 def remap(ds, pcode, mappingFileName, threshold=0.0):
@@ -129,7 +130,7 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
 
     # remove the temporary files
     os.remove(inFileName)
-    os.remove(outFileName)
+    #os.remove(outFileName)
 
     return ds
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -70,9 +70,6 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
     )
     ds_out_all = ds_out_all.drop("timeMonthly_avg_iceAreaCell")
     ds_out_all.to_netcdf(outFileName)
-    print('****',outFileName)
-
-    #shutil.rmtree(outFilePath, ignore_errors=True)
 
 
 def remap(ds, pcode, mappingFileName, threshold=0.0):
@@ -130,7 +127,6 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
 
     # remove the temporary files
     os.remove(inFileName)
-    #os.remove(outFileName)
 
     return ds
 

--- a/tests/cmor_handlers/test_utils.py
+++ b/tests/cmor_handlers/test_utils.py
@@ -45,13 +45,17 @@ class TestLoadAllHandlers:
                 json_file,
             )
 
-    def test_raises_error_if_handler_does_not_exist_for_var(self):
-        with pytest.raises(KeyError):
-            load_all_handlers("lnd", ["invalid_var"])
+    def test_prints_logger_warning_if_handler_does_not_exist_for_var(self, caplog):
+        load_all_handlers("lnd", ["invalid_var"])
 
-    def test_raises_error_if_mpas_handler_does_not_exist_for_var(self):
-        with pytest.raises(KeyError):
-            load_all_handlers("mpaso", cmip_vars=["invalid_var"])
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
+
+    def test_prints_logger_warning_if_mpas_handler_does_not_exist_for_var(self, caplog):
+        load_all_handlers("mpaso", cmip_vars=["invalid_var"])
+
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
 
     def test_updates_CMIP_table_for_variable_based_on_freq_param(self):
         result = load_all_handlers("lnd", cmip_vars=["pr"])
@@ -201,19 +205,27 @@ class TestDeriveHandlers:
                 json_file,
             )
 
-    def test_raises_error_if_handler_is_not_defined_for_a_variable(self):
-        with pytest.raises(KeyError):
-            derive_handlers(
-                self.tables_path,
-                cmip_vars=["undefined_var"],
-                e3sm_vars=["incorrect_e3sm_var"],
-            )
+    def test_prints_logger_warning_if_handler_is_not_defined_for_a_variable(
+        self, caplog
+    ):
+        derive_handlers(
+            self.tables_path,
+            cmip_vars=["undefined_var"],
+            e3sm_vars=["incorrect_e3sm_var"],
+        )
 
-    def test_raises_error_if_handler_cannot_be_derived_from_input_e3sm_vars(self):
-        with pytest.raises(KeyError):
-            derive_handlers(
-                self.tables_path, cmip_vars=["pr"], e3sm_vars=["incorrect_e3sm_var"]
-            )
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
+
+    def test_prints_logger_warning_if_handler_cannot_be_derived_from_input_e3sm_vars(
+        self, caplog
+    ):
+        derive_handlers(
+            self.tables_path, cmip_vars=["pr"], e3sm_vars=["incorrect_e3sm_var"]
+        )
+
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
 
     def test_raises_error_if_CMIP6_table_entry_for_variable_and_freq_arg(self):
         with pytest.raises(KeyError):


### PR DESCRIPTION
- Close #202 

This PR updates the KeyError raised for missing handlers and non-derivable variables to logger warning. This allows e3sm_to_cmip to continue processing variables that do have defined handlers or can be derived rather than breaking the run, which is how `e3sm_to_cmip <= 1.9.1` behaved.