### PR TITLE
add new formula for rsut and rsutcs

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/_formulas.py
+++ b/e3sm_to_cmip/cmor_handlers/_formulas.py
@@ -223,6 +223,40 @@ def rsuscs(data: Dict[str, np.ndarray], index: int) -> np.ndarray:
     return outdata
 
 
+def rsut(data: Dict[str, np.ndarray], index: int) -> np.ndarray:
+    """
+    rsut = SOLIN - FSNTOA
+
+    pre v3 version:
+    rsut = FSUTOA
+    """
+    try:
+        outdata = (
+            data["SOLIN"][index, :] - data["FSNTOA"][index, :]
+        )
+    except KeyError:
+        outdata = data["FSUTOA"][index, :]
+
+    return outdata
+
+
+def rsutcs(data: Dict[str, np.ndarray], index: int) -> np.ndarray:
+    """
+    rsutcs = SOLIN - FSNTOAC
+
+    pre v3 version:
+    rsutcs = FSUTOAC
+    """
+    try:
+        outdata = (
+            data["SOLIN"][index, :] - data["FSNTOAC"][index, :]
+        )
+    except KeyError:
+        outdata = data["FSUTOAC"][index, :]
+
+    return outdata
+
+
 def rtmt(data: Dict[str, np.ndarray], index: int) -> np.ndarray:
     """
     rtmt = FSNT - FLNT

--- a/e3sm_to_cmip/cmor_handlers/handlers.yaml
+++ b/e3sm_to_cmip/cmor_handlers/handlers.yaml
@@ -579,10 +579,26 @@
     levels: null
 -   name: rsut
     units: W m-2
+    raw_variables: [SOLIN, FSNTOA]
+    table: CMIP6_Amon.json
+    unit_conversion: null
+    formula: SOLIN - FSNTOA
+    positive: up
+    levels: null
+-   name: rsut
+    units: W m-2
     raw_variables: [FSUTOA]
     table: CMIP6_Amon.json
     unit_conversion: null
     formula: null
+    positive: up
+    levels: null
+-   name: rsutcs
+    units: W m-2
+    raw_variables: [SOLIN, FSNTOAC]
+    table: CMIP6_Amon.json
+    unit_conversion: null
+    formula: SOLIN - FSNTOAC
     positive: up
     levels: null
 -   name: rsutcs


### PR DESCRIPTION
FSUTOA and FSUTOAC are used in e3sm_to_cmip for directly getting rsut and rsutcs. For v3 output, both FSUTOA and FSUTOAC are removed. This PR is to update formula to use available variables, i.e.,  rsut = SOLIN - FSNTOA, and rsutcs = SOLIN - FSNTOAC