### PR TITLE
Add lat and lon bounds if missing in input datasets

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -15,6 +15,7 @@ dependencies:
   - pyyaml
   - tqdm
   - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
+  - xcdat >=0.6.0
   # Testing
   # ==================
   - pytest

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -15,6 +15,7 @@ dependencies:
   - pyyaml
   - tqdm
   - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
+  - xcdat >=0.6.0
   # Testing
   # ==================
   - pytest

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -6,11 +6,12 @@ import logging
 import os
 from typing import Any, Dict, KeysView, List, Literal, Optional, Tuple, TypedDict
 
+import cmor
 import numpy as np
 import xarray as xr
+import xcdat as xc
 import yaml
 
-import cmor
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.cmor_handlers import FILL_VALUE, _formulas
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
@@ -383,8 +384,9 @@ class VarHandler(BaseVarHandler):
             filepath = filepaths[index]
             all_filepaths.append(filepath)
 
-        ds = xr.open_mfdataset(
+        ds = xc.open_mfdataset(
             all_filepaths,
+            add_bounds=["X", "Y"],
             decode_times=False,
             combine="nested",
             data_vars="minimal",


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #227 

This PR updates the `VarHandler._get_mfdataset()` to use xCDAT to open the input datasets and adds bounds for lat and lon if they are missing.

### Minimum Reproducible Script
```python
from e3sm_to_cmip.__main__ import E3SMtoCMIP

args = [
    "--var-list",
    "lai",
    "--input",
    "/lcrc/group/e3sm/ac.zhang40/tests/20231012.v3alpha04_trigrid_bgc.piControl.chrysalis/post/lnd/native/ts/monthly/50yr",
    "--output",
    "./",
    "--tables-path",
    "/lcrc/group/e3sm/public_html/diagnostics/e3sm_to_cmip_data/cmip6-cmor-tables/Tables/",
    "--user-metadata",
    "/lcrc/group/e3sm/public_html/diagnostics/e3sm_to_cmip_data/user_metadata.json",
    "--serial",
]

run = E3SMtoCMIP(args)

run.run()

```

### Log Output (Success)
```python
2023-11-27 22:34:27,673 [INFO]: __main__.py(__init__:142) >> --------------------------------------
2023-11-27 22:34:27,673 [INFO]: __main__.py(__init__:142) >> --------------------------------------
2023-11-27 22:34:27,673_673:INFO:__init__:--------------------------------------
2023-11-27 22:34:27,674 [INFO]: __main__.py(__init__:143) >> | E3SM to CMIP Configuration
2023-11-27 22:34:27,674 [INFO]: __main__.py(__init__:143) >> | E3SM to CMIP Configuration
2023-11-27 22:34:27,674_674:INFO:__init__:| E3SM to CMIP Configuration
2023-11-27 22:34:27,675 [INFO]: __main__.py(__init__:144) >> --------------------------------------
2023-11-27 22:34:27,675 [INFO]: __main__.py(__init__:144) >> --------------------------------------
2023-11-27 22:34:27,675_675:INFO:__init__:--------------------------------------
2023-11-27 22:34:27,675 [INFO]: __main__.py(__init__:145) >>     * var_list='['lai']'
2023-11-27 22:34:27,675 [INFO]: __main__.py(__init__:145) >>     * var_list='['lai']'
2023-11-27 22:34:27,675_675:INFO:__init__:    * var_list='['lai']'
2023-11-27 22:34:27,676 [INFO]: __main__.py(__init__:146) >>     * input_path='/lcrc/group/e3sm/ac.zhang40/tests/20231012.v3alpha04_trigrid_bgc.piControl.chrysalis/post/lnd/native/ts/monthly/50yr'
2023-11-27 22:34:27,676 [INFO]: __main__.py(__init__:146) >>     * input_path='/lcrc/group/e3sm/ac.zhang40/tests/20231012.v3alpha04_trigrid_bgc.piControl.chrysalis/post/lnd/native/ts/monthly/50yr'
2023-11-27 22:34:27,676_676:INFO:__init__:    * input_path='/lcrc/group/e3sm/ac.zhang40/tests/20231012.v3alpha04_trigrid_bgc.piControl.chrysalis/post/lnd/native/ts/monthly/50yr'
2023-11-27 22:34:27,677 [INFO]: __main__.py(__init__:147) >>     * output_path='./'
2023-11-27 22:34:27,677 [INFO]: __main__.py(__init__:147) >>     * output_path='./'
2023-11-27 22:34:27,677_677:INFO:__init__:    * output_path='./'
2023-11-27 22:34:27,677 [INFO]: __main__.py(__init__:148) >>     * precheck_path='None'
2023-11-27 22:34:27,677 [INFO]: __main__.py(__init__:148) >>     * precheck_path='None'
2023-11-27 22:34:27,677_677:INFO:__init__:    * precheck_path='None'
2023-11-27 22:34:27,678 [INFO]: __main__.py(__init__:149) >>     * freq='mon'
2023-11-27 22:34:27,678 [INFO]: __main__.py(__init__:149) >>     * freq='mon'
2023-11-27 22:34:27,678_678:INFO:__init__:    * freq='mon'
2023-11-27 22:34:27,679 [INFO]: __main__.py(__init__:150) >>     * realm='atm'
2023-11-27 22:34:27,679 [INFO]: __main__.py(__init__:150) >>     * realm='atm'
2023-11-27 22:34:27,679_679:INFO:__init__:    * realm='atm'
2023-11-27 22:34:27,679 [INFO]: __main__.py(__init__:151) >>     * Writing log output file to: logs/20231127_223427_670596
2023-11-27 22:34:27,679 [INFO]: __main__.py(__init__:151) >>     * Writing log output file to: logs/20231127_223427_670596
2023-11-27 22:34:27,679_679:INFO:__init__:    * Writing log output file to: logs/20231127_223427_670596
2023-11-27 22:34:59,714 [INFO]: __main__.py(_get_handlers:220) >> --------------------------------------
2023-11-27 22:34:59,714 [INFO]: __main__.py(_get_handlers:220) >> --------------------------------------
2023-11-27 22:34:59,714_714:INFO:_get_handlers:--------------------------------------
2023-11-27 22:34:59,715 [INFO]: __main__.py(_get_handlers:221) >> | Derived CMIP6 Variable Handlers
2023-11-27 22:34:59,715 [INFO]: __main__.py(_get_handlers:221) >> | Derived CMIP6 Variable Handlers
2023-11-27 22:34:59,715_715:INFO:_get_handlers:| Derived CMIP6 Variable Handlers
2023-11-27 22:34:59,716 [INFO]: __main__.py(_get_handlers:222) >> --------------------------------------
2023-11-27 22:34:59,716 [INFO]: __main__.py(_get_handlers:222) >> --------------------------------------
2023-11-27 22:34:59,716_716:INFO:_get_handlers:--------------------------------------
2023-11-27 22:34:59,717 [INFO]: __main__.py(_get_handlers:224) >>     * 'lai' -> ['LAISHA', 'LAISUN']
2023-11-27 22:34:59,717 [INFO]: __main__.py(_get_handlers:224) >>     * 'lai' -> ['LAISHA', 'LAISUN']
2023-11-27 22:34:59,717_717:INFO:_get_handlers:    * 'lai' -> ['LAISHA', 'LAISUN']
2023-11-27 22:34:59,757 [INFO]: __main__.py(_run:737) >> --------------------------------------
2023-11-27 22:34:59,757 [INFO]: __main__.py(_run:737) >> --------------------------------------
2023-11-27 22:34:59,757_757:INFO:_run:--------------------------------------
2023-11-27 22:34:59,758 [INFO]: __main__.py(_run:738) >> | Running E3SM to CMIP in Serial
2023-11-27 22:34:59,758 [INFO]: __main__.py(_run:738) >> | Running E3SM to CMIP in Serial
2023-11-27 22:34:59,758_758:INFO:_run:| Running E3SM to CMIP in Serial
2023-11-27 22:34:59,759 [INFO]: __main__.py(_run:739) >> --------------------------------------
2023-11-27 22:34:59,759 [INFO]: __main__.py(_run:739) >> --------------------------------------
2023-11-27 22:34:59,759_759:INFO:_run:--------------------------------------
2023-11-27 22:34:59,765 [INFO]: __main__.py(_run_serial:796) >> Trying to CMORize with handler: {'name': 'lai', 'units': '1', 'raw_variables': ['LAISHA', 'LAISUN'], 'table': 'CMIP6_Lmon.json', 'unit_conversion': None, 'formula': 'LAISHA + LAISUN', 'formula_method': <function lai at 0x1550b83b60c0>, 'positive': None, 'levels': None, 'output_data': None, 'method': <bound method VarHandler.cmorize of <e3sm_to_cmip.cmor_handlers.handler.VarHandler object at 0x1550b80f0350>>}
2023-11-27 22:34:59,765 [INFO]: __main__.py(_run_serial:796) >> Trying to CMORize with handler: {'name': 'lai', 'units': '1', 'raw_variables': ['LAISHA', 'LAISUN'], 'table': 'CMIP6_Lmon.json', 'unit_conversion': None, 'formula': 'LAISHA + LAISUN', 'formula_method': <function lai at 0x1550b83b60c0>, 'positive': None, 'levels': None, 'output_data': None, 'method': <bound method VarHandler.cmorize of <e3sm_to_cmip.cmor_handlers.handler.VarHandler object at 0x1550b80f0350>>}
2023-11-27 22:34:59,765_765:INFO:_run_serial:Trying to CMORize with handler: {'name': 'lai', 'units': '1', 'raw_variables': ['LAISHA', 'LAISUN'], 'table': 'CMIP6_Lmon.json', 'unit_conversion': None, 'formula': 'LAISHA + LAISUN', 'formula_method': <function lai at 0x1550b83b60c0>, 'positive': None, 'levels': None, 'output_data': None, 'method': <bound method VarHandler.cmorize of <e3sm_to_cmip.cmor_handlers.handler.VarHandler object at 0x1550b80f0350>>}
2023-11-27 22:34:59,766 [INFO]: handler.py(cmorize:209) >> lai: Starting CMORizing
2023-11-27 22:34:59,766 [INFO]: handler.py(cmorize:209) >> lai: Starting CMORizing
2023-11-27 22:34:59,766_766:INFO:cmorize:lai: Starting CMORizing
2023-11-27 22:34:59,973 [INFO]: handler.py(_setup_cmor_module:323) >> lai: CMOR setup complete
2023-11-27 22:34:59,973 [INFO]: handler.py(_setup_cmor_module:323) >> lai: CMOR setup complete
2023-11-27 22:34:59,973_973:INFO:_setup_cmor_module:lai: CMOR setup complete
2023-11-27 22:34:59,975 [INFO]: handler.py(cmorize:239) >> lai: loading E3SM variables dict_keys(['LAISHA', 'LAISUN'])
2023-11-27 22:34:59,975 [INFO]: handler.py(cmorize:239) >> lai: loading E3SM variables dict_keys(['LAISHA', 'LAISUN'])
2023-11-27 22:34:59,975_975:INFO:cmorize:lai: loading E3SM variables dict_keys(['LAISHA', 'LAISUN'])
2023-11-27 22:35:03,464 [INFO]: handler.py(cmorize:248) >> lai: creating CMOR variable with CMOR axis objects.
2023-11-27 22:35:03,464 [INFO]: handler.py(cmorize:248) >> lai: creating CMOR variable with CMOR axis objects.
2023-11-27 22:35:03,464_464:INFO:cmorize:lai: creating CMOR variable with CMOR axis objects.
2023-11-27 22:35:05,276 [INFO]: handler.py(_cmor_write:648) >> lai: time span 18250.0 - 36500.0
2023-11-27 22:35:05,276 [INFO]: handler.py(_cmor_write:648) >> lai: time span 18250.0 - 36500.0
2023-11-27 22:35:05,276_276:INFO:_cmor_write:lai: time span 18250.0 - 36500.0
2023-11-27 22:35:05,277 [INFO]: handler.py(_cmor_write:652) >> lai: Writing variable to file...
2023-11-27 22:35:05,277 [INFO]: handler.py(_cmor_write:652) >> lai: Writing variable to file...
2023-11-27 22:35:05,277_277:INFO:_cmor_write:lai: Writing variable to file...
2023-11-27 22:35:14,245 [INFO]: __main__.py(_run_serial:821) >> Finished lai, 1/1 jobs complete
2023-11-27 22:35:14,245 [INFO]: __main__.py(_run_serial:821) >> Finished lai, 1/1 jobs complete
2023-11-27 22:35:14,245_245:INFO:_run_serial:Finished lai, 1/1 jobs complete
2023-11-27 22:35:14,246 [INFO]: __main__.py(_run_serial:836) >> 1 of 1 handlers complete
2023-11-27 22:35:14,246 [INFO]: __main__.py(_run_serial:836) >> 1 of 1 handlers complete
2023-11-27 22:35:14,246_246:INFO:_run_serial:1 of 1 handlers complete
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
