### PR TITLE
Replace `imp` with `importlib`

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -1,6 +1,6 @@
-import importlib
 import os
 from collections import defaultdict
+from importlib.machinery import SourceFileLoader
 from typing import Any, Dict, List, Literal, Optional, Union, get_args
 
 import pandas as pd
@@ -385,14 +385,15 @@ def _get_handlers_from_modules(path: str) -> Dict[str, List[Dict[str, Any]]]:
     return handlers
 
 
-def _get_handler_module(var: str, file_path: str):
+def _get_handler_module(module_name: str, module_path: str):
     """Get the variable handler Python module.
 
     Parameters
     ----------
-    var : str
-        The key of the variable (e.g., "orog").
-    file_path : str
+    module_name : str
+        The name of the module, which should be the key of the variable (e.g.,
+        "orog").
+    module_path : str
         The absolute path to the variable handler Python module.
 
     Returns
@@ -400,7 +401,6 @@ def _get_handler_module(var: str, file_path: str):
     module
         The module.
     """
-    spec = importlib.util.spec_from_file_location(var, file_path)  # type: ignore
-    module = importlib.util.module_from_spec(spec)  # type: ignore
+    module = SourceFileLoader(module_name, module_path).load_module()
 
     return module

--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import os
 from collections import defaultdict
 from typing import Any, Dict, List, Literal, Optional, Union, get_args
@@ -44,8 +44,6 @@ def load_all_handlers(
         The realm.
     cmip_vars : List[str]
         The list of CMIP6 variables to CMORize.
-
-
 
     Returns
     -------
@@ -364,7 +362,7 @@ def _get_handlers_from_modules(path: str) -> Dict[str, List[Dict[str, Any]]]:
             ]:
                 var = file.split(".")[0]
                 filepath = os.path.join(root, file)
-                module = imp.load_source(var, filepath)
+                module = _get_handler_module(var, filepath)
 
                 # NOTE: The value is set to a list with a single dict entry
                 # so that it is compatible with the data structure for storing
@@ -385,3 +383,24 @@ def _get_handlers_from_modules(path: str) -> Dict[str, List[Dict[str, Any]]]:
                 ]
 
     return handlers
+
+
+def _get_handler_module(var: str, file_path: str):
+    """Get the variable handler Python module.
+
+    Parameters
+    ----------
+    var : str
+        The key of the variable (e.g., "orog").
+    file_path : str
+        The absolute path to the variable handler Python module.
+
+    Returns
+    -------
+    module
+        The module.
+    """
+    spec = importlib.util.spec_from_file_location(var, file_path)  # type: ignore
+    module = importlib.util.module_from_spec(spec)  # type: ignore
+
+    return module


### PR DESCRIPTION
- Closes #195 

`imp` is breaking conda-forge from building e3sm_to_cmip (https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=839089&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3).