### PR TITLE
Explicitly close `xr.Dataset` in `VarHandler.cmorize()`

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -261,6 +261,8 @@ class VarHandler(BaseVarHandler):
             else:
                 self._cmor_write_with_time(ds, cmor_var_id, time_dim, cmor_ips_id)
 
+            ds.close()
+
         # NOTE: It is important to close the CMOR module AFTER CMORizing all of
         # the variables. Otherwise, the IDs of cmor objects gets wiped after
         # every loop.

--- a/scripts/debug/549_zppy_debug/549_zppy_ts.py
+++ b/scripts/debug/549_zppy_debug/549_zppy_ts.py
@@ -1,0 +1,35 @@
+from e3sm_to_cmip.__main__ import E3SMtoCMIP
+
+# e3sm_to_cmip --output-path ~/test -v 'lai' --realm lnd --input-path /lcrc/group/e3sm/ac.zhang40/zppy_test_complete_run_output/test-main2-20240216/v2.LR.historical_0201_try7/post/lnd/180x360_aave/ts/monthly/2yr --user-metadata ~/zppy/zppy/templates/e3sm_to_cmip/default_metadata.json --tables-path /lcrc/group/e3sm/diagnostics/cmip6-cmor-tables/Tables --num-proc 12
+
+# This version of CMOR_TABLES_DIR is outdated and fails with `default_metadata.json`
+# CMOR_TABLES_DIR = "/lcrc/group/e3sm/diagnostics/cmip6-cmor-tables/Tables"
+CMOR_TABLES_DIR = "/home/ac.tvo/E3SM-Project/cmip6-cmor-tables/Tables"
+INPUT_DIR = "/lcrc/group/e3sm/ac.zhang40/zppy_test_complete_run_output/test-main2-20240216/v2.LR.historical_0201_try7/post/lnd/180x360_aave/ts/monthly/2yr"
+OUTPUT_PATH = "/home/ac.tvo/E3SM-Project/e3sm_to_cmip/scripts/debug/549_zppy_ts"
+
+# e3sm_to_cmip version
+METADATA_PATH = "/home/ac.tvo/E3SM-Project/e3sm_to_cmip/e3sm_to_cmip/resources/default_metadata.json"
+
+
+args = [
+    "--output-path",
+    OUTPUT_PATH,
+    "--var-list",
+    "lai",
+    "--realm",
+    "lnd",
+    "--input-path",
+    INPUT_DIR,
+    "--user-metadata",
+    METADATA_PATH,
+    "--num-proc",
+    "12",
+    "--tables-path",
+    CMOR_TABLES_DIR,
+    # "--serial",
+]
+
+run = E3SMtoCMIP(args)
+
+run.run()


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

By explicitly closing the multi-file `xr.Dataset` object, we avoid any possibility of resource locking with `.nc` files

This is an attempted fix for https://github.com/E3SM-Project/zppy/issues/549.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
