### PR TITLE
fix table/freq ambiguity for multi-frequency variables

### DIFF
--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -651,14 +651,15 @@ class E3SMtoCMIP:
         messages = []
 
         # if the user just asked for the handler info
-        if self.freq == "mon" and not self.input_path and not self.tables_path:
+        # TONY SAYS: Why does this mode even exist?  And why does it depend upon "freq = mon"?
+        if self.freq == "mon" and not self.input_path and not self.tables_path: # info mode 1
             for handler in self.handlers:
                 hand_msg = get_handler_info_msg(handler)
                 messages.append(hand_msg)
 
         # if the user asked if the variable is included in the table
         # but didnt ask about the files in the inpath
-        elif self.freq and self.tables_path and not self.input_path:
+        elif self.freq and self.tables_path and not self.input_path:    # info mode 2
             for handler in self.handlers:
                 table_info = _get_table_info(self.tables_path, handler["table"])
                 if handler["name"] not in table_info["variable_entry"]:
@@ -666,10 +667,14 @@ class E3SMtoCMIP:
                     print_message(msg, status="error")
                     continue
                 else:
+                    if self.freq == "mon" and handler['table'] == "CMIP6_day.json":
+                        continue
+                    if ( self.freq == "day" or self.freq == "3hr" ) and handler['table'] == "CMIP6_Amon.json":
+                        continue
                     hand_msg = get_handler_info_msg(handler)
                     messages.append(hand_msg)
 
-        elif self.freq and self.tables_path and self.input_path:
+        elif self.freq and self.tables_path and self.input_path:        # info mode 3
 
             file_path = next(Path(self.input_path).glob("*.nc"))
 
@@ -712,7 +717,7 @@ class E3SMtoCMIP:
 
                     if self.freq == "mon" and handler['table'] == "CMIP6_day.json":
                         continue
-                    if self.freq == "day" and handler['table'] == "CMIP6_Amon.json":
+                    if ( self.freq == "day" or self.freq == "3hr" ) and handler['table'] == "CMIP6_Amon.json":
                         continue
 
                     hand_msg = None

--- a/e3sm_to_cmip/cmor_handlers/handlers.yaml
+++ b/e3sm_to_cmip/cmor_handlers/handlers.yaml
@@ -320,6 +320,14 @@
   formula: null
   positive: null
   levels: null
+- name: huss
+  units: "1"
+  raw_variables: [QREFHT]
+  table: CMIP6_day.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
 - name: lai
   units: "1"
   raw_variables: [LAISHA, LAISUN]
@@ -656,26 +664,10 @@
   levels: null
 - name: rsut
   units: W m-2
-  raw_variables: [SOLIN, FSNTOA]
-  table: CMIP6_Amon.json
-  unit_conversion: null
-  formula: SOLIN - FSNTOA
-  positive: up
-  levels: null
-- name: rsut
-  units: W m-2
   raw_variables: [FSUTOA]
   table: CMIP6_Amon.json
   unit_conversion: null
   formula: null
-  positive: up
-  levels: null
-- name: rsutcs
-  units: W m-2
-  raw_variables: [SOLIN, FSNTOAC]
-  table: CMIP6_Amon.json
-  unit_conversion: null
-  formula: SOLIN - FSNTOAC
   positive: up
   levels: null
 - name: rsutcs
@@ -736,6 +728,14 @@
   units: K
   raw_variables: [TREFHT]
   table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
+- name: tas
+  units: K
+  raw_variables: [TREFHT]
+  table: CMIP6_day.json
   unit_conversion: null
   formula: null
   positive: null


### PR DESCRIPTION
## Description

<!--
Change to "info-mode" handling in __main__.py, and some manipulation of handler definitions in handlers.yaml.
Addresses issues with table/freq ambiguity for variables with multiple frequencies (or multiple definitions).
No dependencies.
-->

- Closes #251

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

