### PR TITLE
Fix `example_end_to_end_script` -- changed `area` to `areacella` and added missing comma

### DIFF
--- a/scripts/example_end_to_end_script.sh
+++ b/scripts/example_end_to_end_script.sh
@@ -55,7 +55,7 @@ e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t $tables_path -
 # 2. atm fixed variables
 #--------------------------
 raw_var_list="area,PHIS,LANDFRAC"
-cmip_var_list="area, sftlf, orog"
+cmip_var_list="areacella, sftlf, orog"
 ncremap --map=${map_file} -v area,PHIS,LANDFRAC -I ${input_path} -O ${rgr_dir}/fixed_vars
 
 # CMORIZE Atmosphere fx variables
@@ -140,6 +140,6 @@ e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac
 #    hfsifrazil requires 'config_density0' and 'config_frazil_heat_of_fusion'
 # 3. A restart file for mesh: e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
 # 4. A region masks file for MOC regions: EC30to60E2r2_mocBasinsAndTransects20210623.nc (Needed for variable msftmz: Ocean Meridional Overturning Mass Streamfunction)
-e3sm_to_cmip -s --realm Omon --var-list areacello, fsitherm, hfds, masso, mlotst, sfdsi, sob, soga, sos, sosga, tauuo, tauvo, thetaoga, tob, tos, tosga, volo, wfo, zos, thetaoga, hfsifrazil, masscello, so, thetao, thkcello, uo, vo, volcello, wo zhalfo --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpaso_input/ --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
+e3sm_to_cmip -s --realm Omon --var-list areacello, fsitherm, hfds, masso, mlotst, sfdsi, sob, soga, sos, sosga, tauuo, tauvo, thetaoga, tob, tos, tosga, volo, wfo, zos, thetaoga, hfsifrazil, masscello, so, thetao, thkcello, uo, vo, volcello, wo, zhalfo --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpaso_input/ --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
 
 exit


### PR DESCRIPTION
Changed area to areacella in fx var list, and corrected missing comma in Omon var list in the example_end_to_end script".

## Description

<!--
changed area to areacella in fx var list, and corrected missing comma in Omon var list in the example_end_to_end script. 
-->

- Closes #<ISSUE_NUMBER_HERE>

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
