### PR TITLE
Fix redundant `_FillValue` attribute for MPAS fields

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -345,17 +345,22 @@ def open_mfdataset(
     return ds
 
 
-def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals, unlimited=None):
+def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
+                 unlimited=None):
     """Write an xarray Dataset with NetCDF4 fill values where needed"""
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for variableName in variableNames:
+        if "_FillValue" in ds[variableName].attrs:
+            # There's already a fill value attribute so don't add a new one
+            continue
         isNumeric = np.issubdtype(ds[variableName].dtype, np.number)
         if isNumeric:
             dtype = ds[variableName].dtype
             for fillType in fillValues:
                 if dtype == np.dtype(fillType):
-                    encodingDict[variableName] = {"_FillValue": fillValues[fillType]}
+                    encodingDict[variableName] = \
+                        {"_FillValue": fillValues[fillType]}
                     break
         else:
             encodingDict[variableName] = {"_FillValue": None}


### PR DESCRIPTION
Previously, the `write_netcdf()` function was trying to add a `_FillValue` attribute to variables even if they already had one. With this change, we skip variables that already have a fill value defined

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #<ISSUE_NUMBER_HERE>

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
