### PR TITLE
Consolidate cmor setups and logging

### DIFF
--- a/e3sm_to_cmip/__init__.py
+++ b/e3sm_to_cmip/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for e3sm_to_cmip."""
 
-__version__ = "1.11.2rc2"  # pragma: no cover
+__version__ = "1.11.2"  # pragma: no cover
 
 import os
 

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -658,7 +658,7 @@ class E3SMtoCMIP:
 
         # if the user asked if the variable is included in the table
         # but didnt ask about the files in the inpath
-        elif self.freq and self.tables_path and not self.input_path:
+        elif self.freq and self.tables_path and not self.input_path:    # info mode 2
             for handler in self.handlers:
                 table_info = _get_table_info(self.tables_path, handler["table"])
                 if handler["name"] not in table_info["variable_entry"]:
@@ -666,10 +666,14 @@ class E3SMtoCMIP:
                     print_message(msg, status="error")
                     continue
                 else:
+                    if self.freq == "mon" and handler['table'] == "CMIP6_day.json":
+                        continue
+                    if ( self.freq == "day" or self.freq == "3hr" ) and handler['table'] == "CMIP6_Amon.json":
+                        continue
                     hand_msg = get_handler_info_msg(handler)
                     messages.append(hand_msg)
 
-        elif self.freq and self.tables_path and self.input_path:
+        elif self.freq and self.tables_path and self.input_path:        # info mode 3
 
             file_path = next(Path(self.input_path).glob("*.nc"))
 
@@ -712,7 +716,7 @@ class E3SMtoCMIP:
 
                     if self.freq == "mon" and handler['table'] == "CMIP6_day.json":
                         continue
-                    if self.freq == "day" and handler['table'] == "CMIP6_Amon.json":
+                    if ( self.freq == "day" or self.freq == "3hr" ) and handler['table'] == "CMIP6_Amon.json":
                         continue
 
                     hand_msg = None

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -311,7 +311,8 @@ class E3SMtoCMIP:
             sys.exit(1)
 
         # Parse the arguments and perform validation.
-        parsed_args = argparser.parse_args(args_to_parse)   # (exits here if args == "-h" or "--help" or "--version")
+        # NOTE: exits here if args == "-h" or "--help" or "--version", else validate
+        parsed_args = argparser.parse_args(args_to_parse)
 
         self._validate_parsed_args(parsed_args)
 
@@ -785,7 +786,9 @@ class E3SMtoCMIP:
             1 if an error occurs, else 0
         """
 
+        # TODO: Make this a command-line flag.
         do_pbar = False
+
         try:
             num_handlers = len(self.handlers)
             num_success = 0
@@ -884,6 +887,7 @@ class E3SMtoCMIP:
         pool_res = list()
         will_run = []
 
+        # NOTE: Make this a command-line flag.
         do_pbar = False
 
         for idx, handler in enumerate(self.handlers):
@@ -992,8 +996,8 @@ def main(args: Optional[List[str]] = None):
 
     app = E3SMtoCMIP(args)
 
-    # These calls allow loggers that create default logfiles to avoid being 
-    # instantiated by arguments "--help" or "--version".
+    # These calls allow module loggers that create default logfiles to avoid being 
+    # instantiated by arguments "--help" or "--version" upon import.
     instantiate_util_logger()
     instantiate_h_utils_logger()
     instantiate_handler_logger()

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -162,7 +162,6 @@ class E3SMtoCMIP:
         logger.info(f"    * precheck_path='{self.precheck_path}'")
         logger.info(f"    * freq='{self.freq}'")
         logger.info(f"    * realm='{self.realm}'")
-        # logger.info(f"    * Writing log output file to: {log_filename}")
 
     def run(self):
         # Setup logger information and print out e3sm_to_cmip CLI arguments.

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -99,12 +99,17 @@ class CLIArguments:
 
 class E3SMtoCMIP:
     def __init__(self, args: Optional[List[str]] = None):
+        # logger assignment is moved into __init__ AFTER the call to _parse_args
+        # to prevent the default logfile directory being created whenever a call
+        # to "--help" or "--version" is invoked.  Doing so, however, makes the
+        # logger unavailable to the functions in this class unless made global.
         global logger
+
         # A dictionary of command line arguments.
         parsed_args = self._parse_args(args)
 
-        # Setup this module's logger AFTER args parsed in E3SMtoCMIP init, so that
-        # default log file is NOT created for mere "--help" or "--version" calls.
+        # Setup this module's logger AFTER args are parsed in __init__, so that
+        # default log file is NOT created for "--help" or "--version" calls.
         logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True)
 
         # NOTE: The order of these attributes align with class CLIArguments.
@@ -987,10 +992,7 @@ class E3SMtoCMIP:
         print_message("Hit timeout limit, exiting")
         os.kill(os.getpid(), signal.SIGINT)
 
-logger=None
-
 def main(args: Optional[List[str]] = None):
-    global logger
 
     app = E3SMtoCMIP(args)
 

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -969,6 +969,7 @@ class E3SMtoCMIP:
                 logger.info(msg)
             except Exception as e:
                 print_debug(e)
+
             if do_pbar:
                 pbar.update(1)
 

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -975,6 +975,7 @@ class E3SMtoCMIP:
 
         if do_pbar:
             pbar.close()
+
         pool.shutdown()
 
         msg = f"{num_success} of {num_handlers} handlers complete"

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 from e3sm_to_cmip import ROOT_HANDLERS_DIR, __version__, resources
 from datetime import datetime, timezone
 
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 from e3sm_to_cmip.cmor_handlers.utils import (
     instantiate_h_utils_logger,
@@ -105,7 +105,7 @@ class E3SMtoCMIP:
 
         # Setup this module's logger AFTER args parsed in E3SMtoCMIP init, so that
         # default log file is NOT created for mere "--help" or "--version" calls.
-        logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True)
+        logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True)
 
         # NOTE: The order of these attributes align with class CLIArguments.
         # ======================================================================
@@ -641,14 +641,14 @@ class E3SMtoCMIP:
         if not self.simple_mode:
             copy_user_metadata(self.user_metadata, self.output_path)
 
-        # Setup temp storage directory
-        # temp_path = os.environ.get("TMPDIR")
-        # if temp_path is None:
-        #     temp_path = f"{self.output_path}/tmp"
-        #     if not os.path.exists(temp_path):
-        #         os.makedirs(temp_path)
+        Setup temp storage directory
+        temp_path = os.environ.get("TMPDIR")
+        if temp_path is None:
+            temp_path = f"{self.output_path}/tmp"
+            if not os.path.exists(temp_path):
+                os.makedirs(temp_path)
 
-        # tempfile.tempdir = temp_path
+        tempfile.tempdir = temp_path
 
     def _run_info_mode(self):  # noqa: C901
         logger.info("--------------------------------------")
@@ -828,7 +828,7 @@ class E3SMtoCMIP:
                     }
 
                 msg = f"Trying to CMORize with handler: {handler}"
-                logger.critical(msg)
+                logger.info(msg)
 
                 # NOTE: We need a try and except statement here for TypeError because
                 # the VarHandler.cmorize method does not use **kwargs, while the handle
@@ -887,7 +887,7 @@ class E3SMtoCMIP:
         pool_res = list()
         will_run = []
 
-        # NOTE: Make this a command-line flag.
+        # TODO: Make this a command-line flag.
         do_pbar = False
 
         for idx, handler in enumerate(self.handlers):
@@ -989,8 +989,6 @@ class E3SMtoCMIP:
 
 logger=None
 
-def main(args: Optional[List[str]] = None):
-    global logger
 def main(args: Optional[List[str]] = None):
     global logger
 

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 from e3sm_to_cmip import ROOT_HANDLERS_DIR, __version__, resources
 from datetime import datetime, timezone
 
+import logging
 from e3sm_to_cmip._logger import _logger
 
 from e3sm_to_cmip.cmor_handlers.utils import (
@@ -110,7 +111,7 @@ class E3SMtoCMIP:
 
         # Setup this module's logger AFTER args are parsed in __init__, so that
         # default log file is NOT created for "--help" or "--version" calls.
-        logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True)
+        logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True)
 
         # NOTE: The order of these attributes align with class CLIArguments.
         # ======================================================================

--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -641,7 +641,7 @@ class E3SMtoCMIP:
         if not self.simple_mode:
             copy_user_metadata(self.user_metadata, self.output_path)
 
-        Setup temp storage directory
+        # Setup temp storage directory
         temp_path = os.environ.get("TMPDIR")
         if temp_path is None:
             temp_path = f"{self.output_path}/tmp"

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -8,8 +8,16 @@ DEFAULT_LOG_LEVEL = logging.DEBUG
 DEFAULT_LOG_DIR = "e2c_logs"
 DEFAULT_LOG = f"{DEFAULT_LOG_DIR}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
 
-def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
-    """ Return a root or named logger with variable configuration.
+
+def _logger(
+    name=None,
+    logfilename=DEFAULT_LOG,
+    log_level=None,
+    to_console=False,
+    to_logfile=False,
+    propagate=False,
+):
+    """Return a root or named logger with variable configuration.
 
     Parameters
     ----------
@@ -19,8 +27,9 @@ def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=F
     logfilename : str
         If logfile handling is requested, any logfile may be specified, or else
         the default (e2c_logs/dflt_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log) is used.
-    set_log_level : str
-        One of { "DEBUG" (default), "INFO", "WARNING", "ERROR", "CRITICAL" }
+    log_level : int
+        One of { logging.DEBUG (default), logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL }
+        as defined in the module "logging".
     to_console : boolean
         If True, a logging.StreamHandler is supplied.  Default = False
     to_logfile : boolean
@@ -40,17 +49,8 @@ def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=F
 
     logger.propagate = propagate
 
-    if set_log_level == "None" or set_log_level == "DEBUG":
+    if log_level == None:
         log_level = DEFAULT_LOG_LEVEL
-    elif set_log_level == "INFO":
-        log_level = logging.INFO
-    elif set_log_level == "WARNING":
-        log_level = logging.WARNING
-    elif set_log_level == "ERROR":
-        log_level = logging.ERROR
-    elif set_log_level == "CRITICAL":
-        log_level = logging.CRITICAL
-    else: log_level = DEFAULT_LOG_LEVEL
 
     logger.setLevel(log_level)
 
@@ -70,5 +70,3 @@ def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=F
         logger.addHandler(logFileHandler)
 
     return logger
-
-

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -9,7 +9,7 @@ DEFAULT_LOG_LEVEL = logging.DEBUG
 DEFAULT_LOG_DIR = "e2c_logs"
 DEFAULT_LOG = f"{default_log_dir}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
 
-def e2c_logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
+def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
     """ Return a root or named logger with variable configuration.
 
     Parameters

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 DEFAULT_LOG_LEVEL = logging.DEBUG
 DEFAULT_LOG_DIR = "e2c_logs"
-DEFAULT_LOG = f"{default_log_dir}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
+DEFAULT_LOG = f"{DEFAULT_LOG_DIR}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
 
 def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
     """ Return a root or named logger with variable configuration.

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -3,15 +3,6 @@ import logging
 import os
 from datetime import datetime, timezone
 
-'''
-    ACCEPTS:
-        name=<anyname>
-        logfilename=<anypath/file>      [default = e2c_logs/dflt_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log]
-        log_level=<level>               [default = DEBUG]
-        to_console=[True|False]         [default = False]
-        to_logfile=[True|False]         [default = False]
-        propagate=[True|False]          [default = False]
-'''
 
 DEFAULT_LOG_LEVEL = logging.DEBUG
 
@@ -19,15 +10,35 @@ DEFAULT_LOG_DIR = "e2c_logs"
 DEFAULT_LOG = f"{default_log_dir}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
 
 def e2c_logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
+    """ Return a root or named logger with variable configuration.
 
+    Parameters
+    ----------
+    name : str
+        The name displayed for the logger in messages.
+        If name == None or name == "__main__", the root logger is returned
+    logfilename : str
+        If logfile handling is requested, any logfile may be specified, or else
+        the default (e2c_logs/dflt_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log) is used.
+    set_log_level : str
+        One of { "DEBUG" (default), "INFO", "WARNING", "ERROR", "CRITICAL" }
+    to_console : boolean
+        If True, a logging.StreamHandler is supplied.  Default = False
+    to_logfile : boolean
+        If True, a logging.FileHandler is supplied. Default = False.
+    propagate : boolean
+        If True, messages logged are propagated to the root logger.  Default = False.
+    """
+  
     if to_logfile:
         dn = os.path.dirname(logfilename)
         if len(dn) and not os.path.exists(dn):
             os.makedirs(dn)
 
-    logger = logging.getLogger(name)
     if name == None or name == "__main__":
         logger = logger.root
+    else:
+        logger = logging.getLogger(name)
 
     logger.propagate = propagate
 
@@ -47,14 +58,17 @@ def e2c_logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_consol
 
     logger.handlers = []
 
+    msgfmt = "%(asctime)s_%(msecs)03d:%(levelname)s:%(name)s:%(funcName)s:%(message)s"
+    datefmt = "%Y%m%d_%H%M%S"
+
     if to_console:
         logStreamHandler = logging.StreamHandler()
-        logStreamHandler.setFormatter(logging.Formatter("%(asctime)s_%(msecs)03d:%(levelname)s:%(name)s:%(funcName)s:%(message)s",datefmt="%Y%m%d_%H%M%S"))
+        logStreamHandler.setFormatter(logging.Formatter(msgfmt, datefmt=datefmt))
         logger.addHandler(logStreamHandler)
 
     if to_logfile:
         logFileHandler = logging.FileHandler(logfilename)
-        logFileHandler.setFormatter(logging.Formatter("%(asctime)s_%(msecs)03d:%(levelname)s:%(name)s:%(funcName)s:%(message)s",datefmt="%Y%m%d_%H%M%S"))
+        logFileHandler.setFormatter(logging.Formatter(msgfmt, datefmt=datefmt))
         logger.addHandler(logFileHandler)
 
     return logger

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -1,8 +1,6 @@
-import inspect
 import logging
 import os
 from datetime import datetime, timezone
-
 
 DEFAULT_LOG_LEVEL = logging.DEBUG
 DEFAULT_LOG_DIR = "e2c_logs"
@@ -10,12 +8,12 @@ DEFAULT_LOG = f"{DEFAULT_LOG_DIR}/e2c_root_log-{datetime.now(timezone.utc).strft
 
 
 def _logger(
-    name=None,
-    logfilename=DEFAULT_LOG,
-    log_level=None,
-    to_console=False,
-    to_logfile=False,
-    propagate=False,
+    name: str | None = None,
+    logfilename: str = DEFAULT_LOG,
+    log_level: int = DEFAULT_LOG_LEVEL,
+    to_console: bool = False,
+    to_logfile: bool = False,
+    propagate: bool = False,
 ):
     """Return a root or named logger with variable configuration.
 
@@ -28,30 +26,27 @@ def _logger(
         If logfile handling is requested, any logfile may be specified, or else
         the default (e2c_logs/dflt_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log) is used.
     log_level : int
-        One of { logging.DEBUG (default), logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL }
-        as defined in the module "logging".
-    to_console : boolean
-        If True, a logging.StreamHandler is supplied.  Default = False
-    to_logfile : boolean
-        If True, a logging.FileHandler is supplied. Default = False.
+        Logging.DEBUG (default), logging.INFO, logging.WARNING, logging.ERROR,
+        or logging.CRITICAL, by default logging.DEBUG.
+    to_console : bool
+        If True, a logging.StreamHandler is supplied, by default False.
+    to_logfile : bool
+        If True, a logging.FileHandler is supplied, by default False.
     propagate : boolean
-        If True, messages logged are propagated to the root logger.  Default = False.
+        If True, messages logged are propagated to the root logger, by default
+        False.
     """
     if to_logfile:
         dn = os.path.dirname(logfilename)
         if len(dn) and not os.path.exists(dn):
             os.makedirs(dn)
 
-    if name == None or name == "__main__":
-        logger = logger.root
+    if name is None or name == "__main__":
+        logger = logger.root  # noqa: F821
     else:
         logger = logging.getLogger(name)
 
     logger.propagate = propagate
-
-    if log_level == None:
-        log_level = DEFAULT_LOG_LEVEL
-
     logger.setLevel(log_level)
 
     logger.handlers = []

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -13,16 +13,12 @@ from datetime import datetime, timezone
         propagate=[True|False]          [default = False]
 '''
 
-default_log_dir = "e2c_logs"
-default_log = f"{default_log_dir}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
+DEFAULT_LOG_LEVEL = logging.DEBUG
 
-def e2c_logger(name=None, logfilename=default_log, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
+DEFAULT_LOG_DIR = "e2c_logs"
+DEFAULT_LOG = f"{default_log_dir}/e2c_root_log-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}.log"
 
-    # print(f"DEBUG: _logger: entered e2c_logger at {datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')} called by {name}", flush=True)
-
-    default_log_lvl = logging.DEBUG
-
-    # create logging directory as required
+def e2c_logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=False, to_logfile=False, propagate=False):
 
     if to_logfile:
         dn = os.path.dirname(logfilename)
@@ -36,7 +32,7 @@ def e2c_logger(name=None, logfilename=default_log, set_log_level=None, to_consol
     logger.propagate = propagate
 
     if set_log_level == "None" or set_log_level == "DEBUG":
-        log_level = default_log_lvl
+        log_level = DEFAULT_LOG_LEVEL
     elif set_log_level == "INFO":
         log_level = logging.INFO
     elif set_log_level == "WARNING":
@@ -45,7 +41,7 @@ def e2c_logger(name=None, logfilename=default_log, set_log_level=None, to_consol
         log_level = logging.ERROR
     elif set_log_level == "CRITICAL":
         log_level = logging.CRITICAL
-    else: log_level = default_log_lvl
+    else: log_level = DEFAULT_LOG_LEVEL
 
     logger.setLevel(log_level)
 

--- a/e3sm_to_cmip/_logger.py
+++ b/e3sm_to_cmip/_logger.py
@@ -28,7 +28,6 @@ def _logger(name=None, logfilename=DEFAULT_LOG, set_log_level=None, to_console=F
     propagate : boolean
         If True, messages logged are propagated to the root logger.  Default = False.
     """
-  
     if to_logfile:
         dn = os.path.dirname(logfilename)
         if len(dn) and not os.path.exists(dn):

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -322,18 +322,18 @@ class VarHandler(BaseVarHandler):
         logdir : str | None
             The optional log directory.
         """
-        # if log_dir is not None:
-        #     logpath = log_dir
-        # else:
-        #     cwd = os.getcwd()
-        #     logpath = os.path.join(cwd, "cmor_logs")
+        if log_dir is not None:
+            logpath = log_dir
+        else:
+            cwd = os.getcwd()
+            logpath = os.path.join(cwd, "cmor_logs")
 
-        # os.makedirs(logpath, exist_ok=True)
-        # logfile = os.path.join(logpath, var_name + ".log")
+        os.makedirs(logpath, exist_ok=True)
+        logfile = os.path.join(logpath, var_name + ".log")
 
         print("DEBUG: EMPLOYED HANDLER.PY _setup_cmor_module()", flush=True)
 
-        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile="/dev/null")
+        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile=logfile)
         cmor.dataset_json(metadata_path)
         cmor.load_table(self.table)
 

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -15,7 +15,7 @@ from e3sm_to_cmip.cmor_handlers import FILL_VALUE, _formulas
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
 from e3sm_to_cmip._logger import _logger
 
-logger=None
+logger = None
 
 def instantiate_handler_logger():
     global logger

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -13,6 +13,7 @@ import yaml
 
 from e3sm_to_cmip.cmor_handlers import FILL_VALUE, _formulas
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
+import logging
 from e3sm_to_cmip._logger import _logger
 
 logger = None
@@ -20,7 +21,7 @@ logger = None
 def instantiate_handler_logger():
     global logger
 
-    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=True)
+    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=True)
 
 
 # The names for valid hybrid sigma levels.

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import json
+import logging
 import os
 from typing import Any, Dict, KeysView, List, Literal, Optional, Tuple, TypedDict
 
@@ -11,17 +12,19 @@ import xarray as xr
 import xcdat as xc
 import yaml
 
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip.cmor_handlers import FILL_VALUE, _formulas
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
-import logging
-from e3sm_to_cmip._logger import _logger
 
 logger = None
 
-def instantiate_handler_logger():
+
+def _instantiate_handler_logger():
     global logger
 
-    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=True)
+    logger = _logger(
+        name=__name__, log_level=logging.INFO, to_logfile=True, propagate=True
+    )
 
 
 # The names for valid hybrid sigma levels.
@@ -273,9 +276,7 @@ class VarHandler(BaseVarHandler):
         # the variables. Otherwise, the IDs of cmor objects gets wiped after
         # every loop.
         cmor.close()
-        logger.info(
-            f"{self.name}: CMORized and file write complete, closing CMOR I/O."
-        )
+        logger.info(f"{self.name}: CMORized and file write complete, closing CMOR I/O.")
 
         return self.name
 
@@ -332,7 +333,9 @@ class VarHandler(BaseVarHandler):
         os.makedirs(logpath, exist_ok=True)
         logfile = os.path.join(logpath, var_name + ".log")
 
-        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
+        cmor.setup(
+            inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile
+        )
         cmor.dataset_json(metadata_path)
         cmor.load_table(self.table)
 

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -13,14 +13,14 @@ import yaml
 
 from e3sm_to_cmip.cmor_handlers import FILL_VALUE, _formulas
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 logger=None
 
 def instantiate_handler_logger():
     global logger
 
-    logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=True)
+    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=True)
 
 
 # The names for valid hybrid sigma levels.

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -331,9 +331,7 @@ class VarHandler(BaseVarHandler):
         os.makedirs(logpath, exist_ok=True)
         logfile = os.path.join(logpath, var_name + ".log")
 
-        print("DEBUG: EMPLOYED HANDLER.PY _setup_cmor_module()", flush=True)
-
-        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile=logfile)
+        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
         cmor.dataset_json(metadata_path)
         cmor.load_table(self.table)
 

--- a/e3sm_to_cmip/cmor_handlers/handlers.yaml
+++ b/e3sm_to_cmip/cmor_handlers/handlers.yaml
@@ -320,6 +320,14 @@
   formula: null
   positive: null
   levels: null
+- name: huss
+  units: "1"
+  raw_variables: [QREFHT]
+  table: CMIP6_day.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
 - name: lai
   units: "1"
   raw_variables: [LAISHA, LAISUN]
@@ -736,6 +744,14 @@
   units: K
   raw_variables: [TREFHT]
   table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
+- name: tas
+  units: K
+  raw_variables: [TREFHT]
+  table: CMIP6_day.json
   unit_conversion: null
   formula: null
   positive: null

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -5,7 +5,7 @@ import xarray
 
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPAS_mesh', 'MPAS_map']
@@ -15,7 +15,7 @@ VAR_NAME = 'areacello'
 VAR_UNITS = 'm2'
 TABLE = 'CMIP6_Ofx.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -2,10 +2,11 @@
 compute  Grid-Cell Area for Ocean Variables areacello
 """
 import xarray
-import logging
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPAS_mesh', 'MPAS_map']
@@ -41,7 +42,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -65,8 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # area_b is in square radians, so need to multiply by the earth_radius**2
     ds[VAR_NAME] = earth_radius**2*area_b*ds[VAR_NAME]
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-               user_input_path=user_input_path)
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'latitude',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -2,6 +2,7 @@
 compute  Grid-Cell Area for Ocean Variables areacello
 """
 import xarray
+import logging
 
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -15,7 +16,7 @@ VAR_NAME = 'areacello'
 VAR_UNITS = 'm2'
 TABLE = 'CMIP6_Ofx.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -6,7 +6,6 @@ import xarray
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPAS_mesh', 'MPAS_map']
@@ -16,6 +15,7 @@ VAR_NAME = 'areacello'
 VAR_UNITS = 'm2'
 TABLE = 'CMIP6_Ofx.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -66,7 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # area_b is in square radians, so need to multiply by the earth_radius**2
     ds[VAR_NAME] = earth_radius**2*area_b*ds[VAR_NAME]
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'latitude',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -5,9 +5,11 @@ compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -43,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -60,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -6,9 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -20,6 +17,7 @@ VAR_NAME = 'fsitherm'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -5,7 +5,7 @@ compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -17,7 +17,7 @@ VAR_NAME = 'fsitherm'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -5,6 +5,7 @@ compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'fsitherm'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -62,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -19,6 +17,7 @@ VAR_NAME = 'hfds'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -5,9 +5,10 @@ compute Downward Heat Flux at Sea Water Surface, hfds
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -73,7 +74,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -5,6 +5,7 @@ compute Downward Heat Flux at Sea Water Surface, hfds
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'hfds'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -5,7 +5,7 @@ compute Downward Heat Flux at Sea Water Surface, hfds
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -17,7 +17,7 @@ VAR_NAME = 'hfds'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -74,7 +74,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -19,6 +17,7 @@ VAR_NAME = 'hfsifrazil'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -5,7 +5,7 @@ compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -17,7 +17,7 @@ VAR_NAME = 'hfsifrazil'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -5,6 +5,7 @@ compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'hfsifrazil'
 VAR_UNITS = 'W m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -5,9 +5,10 @@ compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     timeSeriesFiles = infiles['MPASO']
     mappingFileName = infiles['MPAS_map']
@@ -76,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -77,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import netCDF4
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'masscello'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -5,10 +5,11 @@ compute Ocean Grid-Cell Mass per area, masscello
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
 import netCDF4
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -77,7 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 import netCDF4
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'masscello'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -78,7 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -5,6 +5,7 @@ compute Ocean Grid-Cell Mass per area, masscello
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 import netCDF4
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
@@ -17,7 +18,7 @@ VAR_NAME = 'masscello'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'masso'
 VAR_UNITS = 'kg'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -6,6 +6,7 @@ compute Sea Water Mass, masso
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'masso'
 VAR_UNITS = 'kg'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -6,9 +6,10 @@ compute Sea Water Mass, masso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -6,7 +6,7 @@ compute Sea Water Mass, masso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'masso'
 VAR_UNITS = 'kg'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -70,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -5,9 +5,10 @@ compute Ocean Mixed Layer Thickness Defined by Sigma T, mlotst
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds = mpas.add_mask(ds, cellMask2D)
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -5,7 +5,7 @@ compute Ocean Mixed Layer Thickness Defined by Sigma T, mlotst
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'mlotst'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds = mpas.add_mask(ds, cellMask2D)
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'mlotst'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -5,6 +5,7 @@ compute Ocean Mixed Layer Thickness Defined by Sigma T, mlotst
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'mlotst'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -77,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = ds.rename({'moc': VAR_NAME})
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     region = ['global_ocean',
               'atlantic_arctic_ocean']

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'msftmz'
 VAR_UNITS = 'kg s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -5,6 +5,7 @@ compute Ocean Meridional Overturning Mass Streamfunction, msftmz
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'msftmz'
 VAR_UNITS = 'kg s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -5,9 +5,10 @@ compute Ocean Meridional Overturning Mass Streamfunction, msftmz
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPASO_MOC_regions', 'MPASO_namelist']
@@ -47,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -76,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = ds.rename({'moc': VAR_NAME})
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     region = ['global_ocean',
               'atlantic_arctic_ocean']

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -5,7 +5,7 @@ compute Ocean Meridional Overturning Mass Streamfunction, msftmz
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'msftmz'
 VAR_UNITS = 'kg s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'pbo'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -5,7 +5,7 @@ compute Sea Water Pressure at Sea floor, pbo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'pbo'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -5,9 +5,10 @@ compute Sea Water Pressure at Sea floor, pbo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -84,7 +85,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -85,7 +85,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -5,6 +5,7 @@ compute Sea Water Pressure at Sea floor, pbo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'pbo'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'pso'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -5,6 +5,7 @@ compute Sea Water Pressure at Sea Water Surface, pso
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'pso'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -81,7 +81,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -5,9 +5,10 @@ compute Sea Water Pressure at Sea Water Surface, pso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -80,7 +81,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -5,7 +5,7 @@ compute Sea Water Pressure at Sea Water Surface, pso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'pso'
 VAR_UNITS = 'Pa'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -5,7 +5,7 @@ compute Downward Sea Ice Basal Salt Flux, sfdsi
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'sfdsi'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'sfdsi'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -5,9 +5,10 @@ compute Downward Sea Ice Basal Salt Flux, sfdsi
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -5,6 +5,7 @@ compute Downward Sea Ice Basal Salt Flux, sfdsi
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'sfdsi'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -62,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -6,6 +6,7 @@ Sea-ice area fraction, siconc
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'siconc'
 VAR_UNITS = '%'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -64,7 +64,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -6,9 +6,10 @@ Sea-ice area fraction, siconc
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -63,7 +64,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -6,7 +6,7 @@ Sea-ice area fraction, siconc
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'siconc'
 VAR_UNITS = '%'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'siconc'
 VAR_UNITS = '%'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -6,9 +6,10 @@ Sea-ice mass per area, simass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -41,7 +42,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         the name of the processed variable after processing is complete
     """
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -62,7 +63,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'simass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -63,7 +63,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -6,6 +6,7 @@ Sea-ice mass per area, simass
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 
@@ -17,7 +18,7 @@ VAR_NAME = 'simass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -6,7 +6,7 @@ Sea-ice mass per area, simass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'simass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -6,7 +6,7 @@ Snow mass per area, sisnmass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'sisnmass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -6,6 +6,7 @@ Snow mass per area, sisnmass
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'sisnmass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'sisnmass'
 VAR_UNITS = 'kg m-2'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -6,9 +6,10 @@ Snow mass per area, sisnmass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -6,6 +6,7 @@ Snow thickness, sisnthick
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'sisnthick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'sisnthick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -6,9 +6,10 @@ Snow thickness, sisnthick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -6,7 +6,7 @@ Snow thickness, sisnthick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'sisnthick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -6,6 +6,7 @@ Surface temperature of sea ice, sitemptop
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -18,7 +19,7 @@ VAR_NAME = 'sitemptop'
 VAR_UNITS = 'K'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -6,7 +6,7 @@ Surface temperature of sea ice, sitemptop
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -18,7 +18,7 @@ VAR_NAME = 'sitemptop'
 VAR_UNITS = 'K'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -5,11 +5,11 @@ Surface temperature of sea ice, sitemptop
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -48,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -20,6 +18,7 @@ VAR_NAME = 'sitemptop'
 VAR_UNITS = 'K'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'sithick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -6,7 +6,7 @@ Sea-ice thickness, sithick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'sithick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -6,6 +6,7 @@ Sea-ice thickness, sithick
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'sithick'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -6,9 +6,10 @@ Sea-ice thickness, sithick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'sitimefrac'
 VAR_UNITS = '1'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -6,7 +6,7 @@ Fraction of time steps with sea ice, sitimefrac
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'sitimefrac'
 VAR_UNITS = '1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -66,7 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -6,6 +6,7 @@ Fraction of time steps with sea ice, sitimefrac
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'sitimefrac'
 VAR_UNITS = '1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -6,9 +6,10 @@ Fraction of time steps with sea ice, sitimefrac
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -65,7 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -70,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -6,6 +6,7 @@ X-component of sea ice velocity, siu
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'siu'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'siu'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -6,9 +6,10 @@ X-component of sea ice velocity, siu
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -6,7 +6,7 @@ X-component of sea ice velocity, siu
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'siu'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -6,6 +6,7 @@ Y-component of sea ice velocity, siv
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 from e3sm_to_cmip._logger import _logger
@@ -17,7 +18,7 @@ VAR_NAME = 'siv'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_console=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -9,8 +9,6 @@ import xarray
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
-
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 
@@ -19,6 +17,7 @@ VAR_NAME = 'siv'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -6,10 +6,11 @@ Y-component of sea ice velocity, siv
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
-
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
+
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 
@@ -17,7 +17,7 @@ VAR_NAME = 'siv'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_SImon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -71,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -5,6 +5,7 @@ compute Sea Water Salinity, so
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'so'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -5,9 +5,10 @@ compute Sea Water Salinity, so
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'so'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -5,7 +5,7 @@ compute Sea Water Salinity, so
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'so'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -5,7 +5,7 @@ compute Sea Water Salinity at Sea Floor, sob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'sob'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'sob'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -5,9 +5,10 @@ compute Sea Water Salinity at Sea Floor, sob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -5,6 +5,7 @@ compute Sea Water Salinity at Sea Floor, sob
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 
@@ -16,7 +17,7 @@ VAR_NAME = 'sob'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -71,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'soga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -6,6 +6,7 @@ compute Global Mean Sea Water Salinity, soga
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'soga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -6,7 +6,7 @@ compute Global Mean Sea Water Salinity, soga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'soga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -6,9 +6,10 @@ compute Global Mean Sea Water Salinity, soga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -5,7 +5,7 @@ compute Sea Surface Salinity, sos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'sos'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -5,9 +5,10 @@ compute Sea Surface Salinity, sos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -5,6 +5,7 @@ compute Sea Surface Salinity, sos
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'sos'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'sos'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -5,6 +5,7 @@ compute Global Average Sea Surface Salinity, sosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'sosga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -5,7 +5,7 @@ compute Global Average Sea Surface Salinity, sosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'sosga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -5,9 +5,10 @@ compute Global Average Sea Surface Salinity, sosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'sosga'
 VAR_UNITS = '0.001'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -5,9 +5,10 @@ compute Surface Downward X Stress, tauuo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'tauuo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -62,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -5,6 +5,7 @@ compute Surface Downward X Stress, tauuo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'tauuo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -5,7 +5,7 @@ compute Surface Downward X Stress, tauuo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'tauuo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -5,9 +5,10 @@ compute Surface Downward Y Stress, tauvo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -5,6 +5,7 @@ compute Surface Downward Y Stress, tauvo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'tauvo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'tauvo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -5,7 +5,7 @@ compute Surface Downward Y Stress, tauvo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'tauvo'
 VAR_UNITS = 'N m-2'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -62,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'thetao'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -5,9 +5,10 @@ compute Sea Water Potential Temperature, thetao
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -43,8 +44,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(msg)
         return
         
-    msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    msg = f'Starting {__name__}'
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -5,6 +5,7 @@ compute Sea Water Potential Temperature, thetao
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'thetao'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -5,7 +5,7 @@ compute Sea Water Potential Temperature, thetao
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'thetao'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -6,9 +6,10 @@ compute Global Average Sea Water Potential Temperature, thetaoga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -71,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -6,6 +6,7 @@ compute Global Average Sea Water Potential Temperature, thetaoga
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'thetaoga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'thetaoga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -6,7 +6,7 @@ compute Global Average Sea Water Potential Temperature, thetaoga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'thetaoga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -3,6 +3,7 @@ compute Ocean Model Cell Thickness, thkcello
 """
 
 import xarray
+import logging
 import netCDF4
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
@@ -15,7 +16,7 @@ VAR_NAME = 'thkcello'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -5,8 +5,6 @@ compute Ocean Model Cell Thickness, thkcello
 import xarray
 import netCDF4
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,6 +15,7 @@ VAR_NAME = 'thkcello'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -78,7 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -4,7 +4,7 @@ compute Ocean Model Cell Thickness, thkcello
 
 import xarray
 import netCDF4
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -15,7 +15,7 @@ VAR_NAME = 'thkcello'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -5,9 +5,10 @@ compute Sea Water Potential Temperature at Sea Floor, tob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -5,7 +5,7 @@ compute Sea Water Potential Temperature at Sea Floor, tob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'tob'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -5,6 +5,7 @@ compute Sea Water Potential Temperature at Sea Floor, tob
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'tob'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'tob'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -5,7 +5,7 @@ compute Sea Surface Temperature, tos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'tos'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'tos'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -5,9 +5,10 @@ compute Sea Surface Temperature, tos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -5,6 +5,7 @@ compute Sea Surface Temperature, tos
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'tos'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -5,6 +5,7 @@ compute Global Average Sea Surface Temperature, tosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'tosga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'tosga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -5,7 +5,7 @@ compute Global Average Sea Surface Temperature, tosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'tosga'
 VAR_UNITS = 'degC'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -5,9 +5,10 @@ compute Global Average Sea Surface Temperature, tosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -5,7 +5,7 @@ compute Sea Water X Velocity, uo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'uo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -5,9 +5,10 @@ compute Sea Water X Velocity, uo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -5,6 +5,7 @@ compute Sea Water X Velocity, uo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'uo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'uo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -5,9 +5,10 @@ compute Sea Water Y Velocity, vo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -5,6 +5,7 @@ compute Sea Water Y Velocity, vo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'vo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -5,7 +5,7 @@ compute Sea Water Y Velocity, vo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'vo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'vo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -5,8 +5,6 @@ compute Ocean Grid-Cell Volume, volcello
 import xarray
 import netCDF4
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,6 +15,7 @@ VAR_NAME = 'volcello'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -3,6 +3,7 @@ compute Ocean Grid-Cell Volume, volcello
 """
 
 import xarray
+import logging
 import netCDF4
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
@@ -15,7 +16,7 @@ VAR_NAME = 'volcello'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -86,7 +86,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # multiply variables in this order so they don't get transposed
     ds[VAR_NAME] = ds[VAR_NAME]*earth_radius**2*area_b
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -3,11 +3,12 @@ compute Ocean Grid-Cell Volume, volcello
 """
 
 import xarray
-import logging
 import netCDF4
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 
@@ -43,7 +44,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -85,8 +86,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # multiply variables in this order so they don't get transposed
     ds[VAR_NAME] = ds[VAR_NAME]*earth_radius**2*area_b
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-               user_input_path=user_input_path)
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -4,7 +4,7 @@ compute Ocean Grid-Cell Volume, volcello
 
 import xarray
 import netCDF4
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -15,7 +15,7 @@ VAR_NAME = 'volcello'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds.compute()
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'volo'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -6,9 +6,10 @@ compute Sea Water Volume, volo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -6,6 +6,7 @@ compute Sea Water Volume, volo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'volo'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -6,7 +6,7 @@ compute Sea Water Volume, volo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'volo'
 VAR_UNITS = 'm3'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -5,9 +5,10 @@ compute Water Flux into Sea Water, wfo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -71,7 +72,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,6 +16,7 @@ VAR_NAME = 'wfo'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -72,7 +72,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -5,7 +5,7 @@ compute Water Flux into Sea Water, wfo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -16,7 +16,7 @@ VAR_NAME = 'wfo'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -5,6 +5,7 @@ compute Water Flux into Sea Water, wfo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -16,7 +17,7 @@ VAR_NAME = 'wfo'
 VAR_UNITS = 'kg m-2 s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -71,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 import numpy
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'wo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -5,6 +5,7 @@ compute Sea Water Vertical Velocity, wo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 import numpy
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
@@ -17,7 +18,7 @@ VAR_NAME = 'wo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import numpy
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'wo'
 VAR_UNITS = 'm s-1'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -5,10 +5,11 @@ compute Sea Water Vertical Velocity, wo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
 import numpy
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 import numpy
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -17,7 +17,7 @@ VAR_NAME = 'zhalfo'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import numpy
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,6 +17,7 @@ VAR_NAME = 'zhalfo'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -92,7 +92,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     depth_coord_half = numpy.zeros(nVertLevels+1)
     depth_coord_half[1:] = dsMesh.refBottomDepth.values
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -5,6 +5,7 @@ compute 	Depth Below Geoid of Interfaces Between Ocean Layers, zhalfo
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 import numpy
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
@@ -17,7 +18,7 @@ VAR_NAME = 'zhalfo'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -5,9 +5,10 @@ compute Sea Surface Height Above Geoid, zos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -70,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -5,7 +5,7 @@ compute Sea Surface Height Above Geoid, zos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -17,7 +17,7 @@ VAR_NAME = 'zos'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -5,6 +5,7 @@ compute Sea Surface Height Above Geoid, zos
 from __future__ import absolute_import, division, print_function
 
 import xarray
+import logging
 from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
@@ -17,7 +18,7 @@ VAR_NAME = 'zos'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import xarray
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
@@ -19,6 +17,7 @@ VAR_NAME = 'zos'
 VAR_UNITS = 'm'
 TABLE = 'CMIP6_Omon.json'
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(infiles, tables, user_input_path, **kwargs):
     """

--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -14,12 +14,12 @@ from e3sm_to_cmip import (
 from e3sm_to_cmip.cmor_handlers.handler import VarHandler
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
 
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 def instantiate_h_utils_logger():
     global logger
 
-    logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 
 # Type aliases

--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -14,12 +14,13 @@ from e3sm_to_cmip import (
 from e3sm_to_cmip.cmor_handlers.handler import VarHandler
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
 
+import logging
 from e3sm_to_cmip._logger import _logger
 
 def instantiate_h_utils_logger():
     global logger
 
-    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 
 # Type aliases

--- a/e3sm_to_cmip/cmor_handlers/utils.py
+++ b/e3sm_to_cmip/cmor_handlers/utils.py
@@ -11,16 +11,17 @@ from e3sm_to_cmip import (
     LEGACY_HANDLER_DIR_PATH,
     MPAS_HANDLER_DIR_PATH,
 )
+from e3sm_to_cmip._logger import _logger
 from e3sm_to_cmip.cmor_handlers.handler import VarHandler
 from e3sm_to_cmip.util import _get_table_for_non_monthly_freq
 
-import logging
-from e3sm_to_cmip._logger import _logger
 
-def instantiate_h_utils_logger():
+def _instantiate_h_utils_logger():
     global logger
 
-    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
+    logger = _logger(
+        name=__name__, set_log_level="INFO", to_logfile=True, propagate=False
+    )
 
 
 # Type aliases
@@ -391,5 +392,3 @@ def _get_handlers_from_modules(path: str) -> Dict[str, List[Dict[str, Any]]]:
                 ]
 
     return handlers
-
-

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -13,7 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 # list of raw variable names needed
 RAW_VARIABLES = [str("area")]
 VAR_NAME = str("areacella")
@@ -21,7 +21,7 @@ VAR_UNITS = str("m2")
 TABLE = str("CMIP6_fx.json")
 RADIUS = 6.37122e6
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     logger.info(f"{VAR_NAME}: CMOR setup complete")
 

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -13,10 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
-
 # list of raw variable names needed
 RAW_VARIABLES = [str("area")]
 VAR_NAME = str("areacella")
@@ -24,6 +21,7 @@ VAR_UNITS = str("m2")
 TABLE = str("CMIP6_fx.json")
 RADIUS = 6.37122e6
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -13,6 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
+import logging
 from e3sm_to_cmip._logger import _logger
 # list of raw variable names needed
 RAW_VARIABLES = [str("area")]
@@ -21,7 +22,7 @@ VAR_UNITS = str("m2")
 TABLE = str("CMIP6_fx.json")
 RADIUS = 6.37122e6
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip.util import setup_cmor, print_message
+import logging
 from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
@@ -21,7 +22,7 @@ VAR_NAME = str("clisccp")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_CFmon.json")
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle(  # noqa: C901
     vars_to_filepaths: Dict[str, List[str]],

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -13,9 +13,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip.util import setup_cmor, print_message
-
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("FISCCP1_COSP")]
@@ -23,6 +21,7 @@ VAR_NAME = str("clisccp")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_CFmon.json")
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(  # noqa: C901
     vars_to_filepaths: Dict[str, List[str]],

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -72,7 +72,7 @@ def handle(  # noqa: C901
 
     logger.debug(f"{VAR_NAME}: running with input files: {vars_to_filepaths}")
 
-    setup_cmor(VAR_NAME, tables, TABLE, metadata_path)
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=metadata_path)
 
     logger.info(f"{VAR_NAME}: CMOR setup complete")
 

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -13,7 +13,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip.util import setup_cmor, print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("FISCCP1_COSP")]
@@ -21,7 +21,7 @@ VAR_NAME = str("clisccp")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_CFmon.json")
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle(  # noqa: C901
     vars_to_filepaths: Dict[str, List[str]],

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -13,6 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
+import logging
 from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
@@ -22,7 +23,7 @@ VAR_UNITS = str("m")
 TABLE = str("CMIP6_fx.json")
 GRAV = 9.80616
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -68,7 +68,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     logger.info(f"{VAR_NAME}: CMOR setup complete")
 

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -13,7 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("PHIS")]
@@ -22,7 +22,7 @@ VAR_UNITS = str("m")
 TABLE = str("CMIP6_fx.json")
 GRAV = 9.80616
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -4,7 +4,6 @@ PHIS to orog converter
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-import logging
 import os
 
 import numpy as np
@@ -12,11 +11,11 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip import resources
-from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
-logger = _setup_logger(__name__)
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("PHIS")]
@@ -56,8 +55,7 @@ def handle_simple(infiles):
 
 
 def handle(infiles, tables, user_input_path, table, logdir):
-    msg = f"{VAR_NAME}: Starting"
-    logger.info(msg)
+    logger.info(f"{VAR_NAME}: Starting")
 
     # check that we have some input files for every variable
     zerofiles = False
@@ -65,32 +63,17 @@ def handle(infiles, tables, user_input_path, table, logdir):
         if len(infiles[variable]) == 0:
             msg = f"{VAR_NAME}: Unable to find input files for {variable}"
             print_message(msg)
-            logging.error(msg)
+            logger.error(msg)
             zerofiles = True
     if zerofiles:
         return None
 
-    # Create the logging directory and setup cmor
-    if logdir:
-        logpath = logdir
-    else:
-        outpath, _ = os.path.split(logger.__dict__["handlers"][0].baseFilename)
-        logpath = os.path.join(outpath, "cmor_logs")
-    os.makedirs(logpath, exist_ok=True)
+    setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
-    logfile = os.path.join(logpath, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-
-    cmor.dataset_json(str(user_input_path))
-    cmor.load_table(str(TABLE))
-
-    msg = "{}: CMOR setup complete".format(VAR_NAME)
-    logging.info(msg)
+    logger.info(f"{VAR_NAME}: CMOR setup complete")
 
     # extract data from the input file
-    msg = "orog: loading PHIS"
-    logger.info(msg)
+    logger.info("orog: loading PHIS")
 
     filename = infiles["PHIS"][0]
 
@@ -108,8 +91,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         "PHIS": ds["PHIS"],
     }
 
-    msg = f"{VAR_NAME}: loading axes"
-    logger.info(msg)
+    logger.info(f"{VAR_NAME}: loading axes")
 
     axes = [
         {
@@ -126,8 +108,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         },
     ]
 
-    msg = "orog: running CMOR"
-    logging.info(msg)
+    logger.info("orog: running CMOR")
 
     axis_ids = list()
     for axis in axes:
@@ -139,12 +120,10 @@ def handle(infiles, tables, user_input_path, table, logdir):
     outdata = data["PHIS"].values / GRAV
     cmor.write(varid, outdata)
 
-    msg = "{}: write complete, closing".format(VAR_NAME)
-    logger.debug(msg)
+    logger.debug(f"{VAR_NAME}: write complete, closing")
 
     cmor.close()
 
-    msg = "{}: file close complete".format(VAR_NAME)
-    logger.debug(msg)
+    logger.debug(f"{VAR_NAME}: file close complete")
 
-    return "orog"
+    return VARNAME

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -13,9 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("PHIS")]
@@ -24,6 +22,7 @@ VAR_UNITS = str("m")
 TABLE = str("CMIP6_fx.json")
 GRAV = 9.80616
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=user_input_path)
 
     logger.info(f"{VAR_NAME}: CMOR setup complete")
 

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -13,9 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-
 from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("LANDFRAC")]
@@ -23,6 +21,7 @@ VAR_NAME = str("sftlf")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_fx.json")
 
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -13,6 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
+import logging
 from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
@@ -21,7 +22,7 @@ VAR_NAME = str("sftlf")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_fx.json")
 
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -13,7 +13,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("LANDFRAC")]
@@ -21,7 +21,7 @@ VAR_NAME = str("sftlf")
 VAR_UNITS = str("%")
 TABLE = str("CMIP6_fx.json")
 
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def handle_simple(infiles):
     resource_path, _ = os.path.split(os.path.abspath(resources.__file__))

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -137,7 +137,6 @@ def remap(ds, pcode, mappingFileName, threshold=0.0):
     ds.load()
 
     if delete_tempfiles:
-        # remove the temporary files
         os.remove(inFileName)
         os.remove(outFileName)
 
@@ -409,7 +408,6 @@ def convert_namelist_to_dict(fileName):
 
 def write_cmor(axes, ds, varname, varunits, d2f=True, **kwargs):
     """Write a time series of a variable in the format expected by CMOR"""
-
     axis_ids = list()
     for axis in axes:
         axis_id = cmor.axis(**axis)

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -80,6 +80,7 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
 def remap(ds, pcode, mappingFileName, threshold=0.0):
     """Use ncreamp to remap the xarray Dataset to a new target grid"""
 
+    # TODO:  Make this a global commandline switch
     delete_tempfiles = True
 
     # write the dataset to a temp file
@@ -429,7 +430,8 @@ def write_cmor(axes, ds, varname, varunits, d2f=True, **kwargs):
     )
 
     # adding "shuffle" reduced size on disk by 14%, need to test for performance impact.
-    # if varname not in [ "lat", "lev", "lon" ]:
+    # TODO: Pass a commandline arg "--shuffle" down to this point.
+    # if do_shuffle and varname not in [ "lat", "lev", "lon" ]:
     #     cmor.set_deflate(varid, True, True, 1)
 
     # write out the data

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -22,8 +22,9 @@ import numpy as np
 import xarray
 from dask.diagnostics import ProgressBar
 
+import logging
 from e3sm_to_cmip._logger import _logger
-logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 def run_ncremap_cmd(args, env):
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -22,8 +22,8 @@ import numpy as np
 import xarray
 from dask.diagnostics import ProgressBar
 
-from e3sm_to_cmip._logger import e2c_logger
-logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+from e3sm_to_cmip._logger import _logger
+logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 def run_ncremap_cmd(args, env):
 

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
+import logging
 import os
 import re
 import sys
@@ -14,13 +15,16 @@ import xarray as xr
 import yaml
 from tqdm import tqdm
 
-import logging
 from e3sm_to_cmip._logger import _logger
 
-def instantiate_util_logger():
+
+def _instantiate_util_logger():
     global logger
 
-    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
+    logger = _logger(
+        name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False
+    )
+
 
 ATMOS_TABLES = [
     "CMIP6_Amon.json",
@@ -123,7 +127,6 @@ def setup_cmor(var_name, table_path, table_name, user_input_path):
         cmor.load_table(table_name)
     except Exception:
         raise ValueError(f"Unable to load table {table_name} for {var_name}")
-
 
 
 # ------------------------------------------------------------------
@@ -317,6 +320,7 @@ def _get_table_info(tables, table):
         raise ValueError(f"CMIP6 table doesnt exist: {table}")
     with open(table, "r") as instream:
         return json.load(instream)
+
 
 def get_handler_info_msg(handler):
     msg = {

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -14,12 +14,13 @@ import xarray as xr
 import yaml
 from tqdm import tqdm
 
+import logging
 from e3sm_to_cmip._logger import _logger
 
 def instantiate_util_logger():
     global logger
 
-    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+    logger = _logger(name=__name__, log_level=logging.INFO, to_logfile=True, propagate=False)
 
 ATMOS_TABLES = [
     "CMIP6_Amon.json",

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -109,7 +109,6 @@ def setup_cmor(var_name, table_path, table_name, user_input_path):
     """
     Sets up cmor and logging for a single handler
     """
-
     logfile = os.path.join(os.getcwd(), "cmor_logs")
     if not os.path.exists(logfile):
         os.makedirs(logfile)

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -14,12 +14,12 @@ import xarray as xr
 import yaml
 from tqdm import tqdm
 
-from e3sm_to_cmip._logger import e2c_logger
+from e3sm_to_cmip._logger import _logger
 
 def instantiate_util_logger():
     global logger
 
-    logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
+    logger = _logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 ATMOS_TABLES = [
     "CMIP6_Amon.json",

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -105,7 +105,7 @@ def print_message(message, status="error"):
 # ------------------------------------------------------------------
 
 
-def setup_cmor(varname, table_path, table_name, user_input_path):
+def setup_cmor(var_name, table_path, table_name, user_input_path):
     """
     Sets up cmor and logging for a single handler
     """
@@ -113,7 +113,7 @@ def setup_cmor(varname, table_path, table_name, user_input_path):
     logfile = os.path.join(os.getcwd(), "cmor_logs")
     if not os.path.exists(logfile):
         os.makedirs(logfile)
-    logfile = os.path.join(logfile, varname + ".log")
+    logfile = os.path.join(logfile, var_name + ".log")
 
     cmor.setup(inpath=table_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
 
@@ -122,7 +122,7 @@ def setup_cmor(varname, table_path, table_name, user_input_path):
     try:
         cmor.load_table(table_name)
     except Exception:
-        raise ValueError(f"Unable to load table {table_name} for {varname}")
+        raise ValueError(f"Unable to load table {table_name} for {var_name}")
 
 
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/e3sm_to_cmip"
 
 [version]
-current = "1.11.2rc2"
+current = "1.11.2"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## Description

This update to e2c addresses two areas of consolidation:  setup_cmor functions (calls to cmor.setup) and e2c logging configurations.  Other minor bug-fix and cleanup conducted.  All changes tested against a sample from each variable type (Amon 2D, Amon 3D, day, 3hr, CFmon, Lmon, LImon, Omon, SImon).

**CMOR SETUP CONSOLIDATION**:

The motivation for cmor.setup reconfigurations is that this cmor function was called from 7 separate locations:
- the setup_cmor() in util.py
- the setup_cmor() in mpas.py
- the _setup_cmor_module() in handler.py
- and 4 raw calls to cmor.setup in the areacella.py, clisccp.py, orog.py and sftlf.py variable handlers.

Aside from unnecessary replication of codes, each call to cmor.setup invokes a cmor-internal "logger" setup, whose only external accessibility is the name of the logfile to supply.  There is no ability to alter its propagate(True/False), date-format or other attributes.  (I believe it is responsible for the "duplicated log messages" problem, as only those messages with the CMOR date-format appear to be duplicated.)

**Now**, there are only TWO functions that invoke cmor.setup:  util.setup_cmor(), and handler._setup_cmor_module().  The latter is applied to every handler managed through the "handlers.yaml" construct.  The former handles all other variables.  The function in mpas.py has been eliminated.

**LOGGER CONSOLIDATION:**

Likewise, the motivation in consolidating the logger functions is that python logging is "global" - different modules adding stream or file handlers to their loggers accumulate across all logging.

**Now**, there is a single "e2c_logger()" function in _logger.py, and it is called by ANY (code-accessible) module in e2c that requires logging.  It can be configures to return the root logger, or a named-logger, to apply logging to a file or to console or both, and to propagate or not.

**FIXING** the problem where "--help" and "--version" cause a cmor_logs directory to be created in the user's current directory required some main-line refactoring.  Previously, modules like mpas.py, handler.py, etc each would call their logger setup in the global space.  That global space is activated whenever a module is "imported", irrespective of whether any functions defined within have been called.  And ALL of these imports occur BEFORE we get a chance to parse the main command-line args (and discover that only --help or --version was being invoked.)

Now each of these modules has its own function to be called to set-up its logger.  These are imported into "__main__" and invoked only AFTER arg-parsing is completed (and not at all for --help and --version calls).

**CHANGES BY MODULE**:

Aside from virtually ALL modules now using _logger:e2c_logger() for logging operations, the following changes have been made:

- __main__.py:  Added "num_failures" in parallel to "num_sucesses", to enable a non-zero return status.
- _logger.py:  revamped to contain only "e2c_logger()" function.
- util.py:  generalized "cmor_setup()" to handle both mpas and non-mpas variables.
- mpas.py: removed superfluous "cmor_setup()" function.
- cmor_handler/mpas_vars/<handlers>.py:  Employ util.setup_cmor(), not mpas.setup_cmor().
- handlers areacella, clisccp, orog, sftlf: Employ util.setup_cmor(), not direct cmor.setup calls.

**MINOR CHANGES**:

Replaced some - but not all ".format()" string variable formatting with f"{va}" format style. 

- Closes #220 

## Checklist

- [~] My code follows the style guidelines of this project
- [~] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
