### PR TITLE
Update end to end script

### DIFF
--- a/e3sm_to_cmip/__main__.py
+++ b/e3sm_to_cmip/__main__.py
@@ -311,7 +311,8 @@ class E3SMtoCMIP:
             sys.exit(1)
 
         # Parse the arguments and perform validation.
-        parsed_args = argparser.parse_args(args_to_parse)   # (exits here if args == "-h" or "--help" or "--version")
+        # NOTE: exits here if args == "-h" or "--help" or "--version", else validate
+        parsed_args = argparser.parse_args(args_to_parse)
 
         self._validate_parsed_args(parsed_args)
 
@@ -785,7 +786,9 @@ class E3SMtoCMIP:
             1 if an error occurs, else 0
         """
 
+        # TODO: Make this a command-line flag.
         do_pbar = False
+
         try:
             num_handlers = len(self.handlers)
             num_success = 0
@@ -884,6 +887,7 @@ class E3SMtoCMIP:
         pool_res = list()
         will_run = []
 
+        # NOTE: Make this a command-line flag.
         do_pbar = False
 
         for idx, handler in enumerate(self.handlers):
@@ -992,8 +996,8 @@ def main(args: Optional[List[str]] = None):
 
     app = E3SMtoCMIP(args)
 
-    # These calls allow loggers that create default logfiles to avoid being 
-    # instantiated by arguments "--help" or "--version".
+    # These calls allow module loggers that create default logfiles to avoid being 
+    # instantiated by arguments "--help" or "--version" upon import.
     instantiate_util_logger()
     instantiate_h_utils_logger()
     instantiate_handler_logger()

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -322,18 +322,18 @@ class VarHandler(BaseVarHandler):
         logdir : str | None
             The optional log directory.
         """
-        # if log_dir is not None:
-        #     logpath = log_dir
-        # else:
-        #     cwd = os.getcwd()
-        #     logpath = os.path.join(cwd, "cmor_logs")
+        if log_dir is not None:
+            logpath = log_dir
+        else:
+            cwd = os.getcwd()
+            logpath = os.path.join(cwd, "cmor_logs")
 
-        # os.makedirs(logpath, exist_ok=True)
-        # logfile = os.path.join(logpath, var_name + ".log")
+        os.makedirs(logpath, exist_ok=True)
+        logfile = os.path.join(logpath, var_name + ".log")
 
         print("DEBUG: EMPLOYED HANDLER.PY _setup_cmor_module()", flush=True)
 
-        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile="/dev/null")
+        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile=logfile)
         cmor.dataset_json(metadata_path)
         cmor.load_table(self.table)
 

--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -331,9 +331,7 @@ class VarHandler(BaseVarHandler):
         os.makedirs(logpath, exist_ok=True)
         logfile = os.path.join(logpath, var_name + ".log")
 
-        print("DEBUG: EMPLOYED HANDLER.PY _setup_cmor_module()", flush=True)
-
-        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE,logfile=logfile)
+        cmor.setup(inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
         cmor.dataset_json(metadata_path)
         cmor.load_table(self.table)
 

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -2,10 +2,11 @@
 compute  Grid-Cell Area for Ocean Variables areacello
 """
 import xarray
-import logging
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPAS_mesh', 'MPAS_map']
@@ -41,7 +42,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -65,8 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # area_b is in square radians, so need to multiply by the earth_radius**2
     ds[VAR_NAME] = earth_radius**2*area_b*ds[VAR_NAME]
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-               user_input_path=user_input_path)
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'latitude',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -5,9 +5,11 @@ compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -43,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -60,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -5,9 +5,10 @@ compute Downward Heat Flux at Sea Water Surface, hfds
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -73,7 +74,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -5,9 +5,10 @@ compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f'Simple CMOR output not supported for {VAR_NAME}', 'error')
         return None
 
-    logging.info(f'Starting {VAR_NAME}')
+    logger.info(f'Starting {VAR_NAME}')
 
     timeSeriesFiles = infiles['MPASO']
     mappingFileName = infiles['MPAS_map']
@@ -76,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -5,10 +5,11 @@ compute Ocean Grid-Cell Mass per area, masscello
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
 import netCDF4
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -77,7 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -6,9 +6,10 @@ compute Sea Water Mass, masso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -5,9 +5,10 @@ compute Ocean Mixed Layer Thickness Defined by Sigma T, mlotst
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds = mpas.add_mask(ds, cellMask2D)
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -5,9 +5,10 @@ compute Ocean Meridional Overturning Mass Streamfunction, msftmz
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPASO_MOC_regions', 'MPASO_namelist']
@@ -47,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -76,7 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = ds.rename({'moc': VAR_NAME})
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     region = ['global_ocean',
               'atlantic_arctic_ocean']

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -5,9 +5,10 @@ compute Sea Water Pressure at Sea floor, pbo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -84,7 +85,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -5,9 +5,10 @@ compute Sea Water Pressure at Sea Water Surface, pso
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles['MPASO_namelist']
     meshFileName = infiles['MPAS_mesh']
@@ -80,7 +81,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -5,9 +5,10 @@ compute Downward Sea Ice Basal Salt Flux, sfdsi
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -6,9 +6,10 @@ Sea-ice area fraction, siconc
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -63,7 +64,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -6,9 +6,10 @@ Sea-ice mass per area, simass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -41,7 +42,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         the name of the processed variable after processing is complete
     """
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -62,7 +63,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -6,9 +6,10 @@ Snow mass per area, sisnmass
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -6,9 +6,10 @@ Snow thickness, sisnthick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -5,11 +5,11 @@ Surface temperature of sea ice, sitemptop
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -48,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -6,9 +6,10 @@ Sea-ice thickness, sithick
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -6,9 +6,10 @@ Fraction of time steps with sea ice, sitimefrac
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -65,7 +66,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -6,9 +6,10 @@ X-component of sea ice velocity, siu
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -6,10 +6,11 @@ Y-component of sea ice velocity, siv
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
-
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_console=True, propagate=False)
+
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
 
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -5,9 +5,10 @@ compute Sea Water Salinity, so
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -5,9 +5,10 @@ compute Sea Water Salinity at Sea Floor, sob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -6,9 +6,10 @@ compute Global Mean Sea Water Salinity, soga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -5,9 +5,10 @@ compute Sea Surface Salinity, sos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -5,9 +5,10 @@ compute Global Average Sea Surface Salinity, sosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -5,9 +5,10 @@ compute Surface Downward X Stress, tauuo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -5,9 +5,10 @@ compute Surface Downward Y Stress, tauvo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -61,7 +62,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -5,9 +5,10 @@ compute Sea Water Potential Temperature, thetao
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -43,8 +44,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(msg)
         return
         
-    msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    msg = f'Starting {__name__}'
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -6,9 +6,10 @@ compute Global Average Sea Water Potential Temperature, thetaoga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -5,9 +5,10 @@ compute Sea Water Potential Temperature at Sea Floor, tob
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -5,9 +5,10 @@ compute Sea Surface Temperature, tos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -5,9 +5,10 @@ compute Global Average Sea Surface Temperature, tosga
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -66,7 +67,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -5,9 +5,10 @@ compute Sea Water X Velocity, uo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -5,9 +5,10 @@ compute Sea Water Y Velocity, vo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -44,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -3,11 +3,12 @@ compute Ocean Grid-Cell Volume, volcello
 """
 
 import xarray
-import logging
 import netCDF4
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 
@@ -43,7 +44,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -85,8 +86,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # multiply variables in this order so they don't get transposed
     ds[VAR_NAME] = ds[VAR_NAME]*earth_radius**2*area_b
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-               user_input_path=user_input_path)
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -6,9 +6,10 @@ compute Sea Water Volume, volo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     timeSeriesFiles = infiles['MPASO']
@@ -67,7 +68,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -5,9 +5,10 @@ compute Water Flux into Sea Water, wfo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -46,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles['MPAS_map']
     timeSeriesFiles = infiles['MPASO']
@@ -71,7 +72,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -5,10 +5,11 @@ compute Sea Water Vertical Velocity, wo
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
 import numpy
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -70,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -5,9 +5,10 @@ compute Sea Surface Height Above Geoid, zos
 from __future__ import absolute_import, division, print_function
 
 import xarray
-import logging
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -45,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
         
     msg = 'Starting {name}'.format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles['MPAS_mesh']
     mappingFileName = infiles['MPAS_map']
@@ -69,7 +70,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -4,7 +4,6 @@ PHIS to orog converter
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-import logging
 import os
 
 import numpy as np
@@ -12,11 +11,11 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip import resources
-from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
-logger = _setup_logger(__name__)
+from e3sm_to_cmip._logger import e2c_logger
+logger = e2c_logger(name=__name__, set_log_level="INFO", to_logfile=True, propagate=False)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("PHIS")]
@@ -56,8 +55,7 @@ def handle_simple(infiles):
 
 
 def handle(infiles, tables, user_input_path, table, logdir):
-    msg = f"{VAR_NAME}: Starting"
-    logger.info(msg)
+    logger.info(f"{VAR_NAME}: Starting")
 
     # check that we have some input files for every variable
     zerofiles = False
@@ -65,32 +63,17 @@ def handle(infiles, tables, user_input_path, table, logdir):
         if len(infiles[variable]) == 0:
             msg = f"{VAR_NAME}: Unable to find input files for {variable}"
             print_message(msg)
-            logging.error(msg)
+            logger.error(msg)
             zerofiles = True
     if zerofiles:
         return None
 
-    # Create the logging directory and setup cmor
-    if logdir:
-        logpath = logdir
-    else:
-        outpath, _ = os.path.split(logger.__dict__["handlers"][0].baseFilename)
-        logpath = os.path.join(outpath, "cmor_logs")
-    os.makedirs(logpath, exist_ok=True)
+    setup_cmor(VAR_NAME, tables, TABLE, user_input_path)
 
-    logfile = os.path.join(logpath, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-
-    cmor.dataset_json(str(user_input_path))
-    cmor.load_table(str(TABLE))
-
-    msg = "{}: CMOR setup complete".format(VAR_NAME)
-    logging.info(msg)
+    logger.info(f"{VAR_NAME}: CMOR setup complete")
 
     # extract data from the input file
-    msg = "orog: loading PHIS"
-    logger.info(msg)
+    logger.info("orog: loading PHIS")
 
     filename = infiles["PHIS"][0]
 
@@ -108,8 +91,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         "PHIS": ds["PHIS"],
     }
 
-    msg = f"{VAR_NAME}: loading axes"
-    logger.info(msg)
+    logger.info(f"{VAR_NAME}: loading axes")
 
     axes = [
         {
@@ -126,8 +108,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         },
     ]
 
-    msg = "orog: running CMOR"
-    logging.info(msg)
+    logger.info("orog: running CMOR")
 
     axis_ids = list()
     for axis in axes:
@@ -139,12 +120,10 @@ def handle(infiles, tables, user_input_path, table, logdir):
     outdata = data["PHIS"].values / GRAV
     cmor.write(varid, outdata)
 
-    msg = "{}: write complete, closing".format(VAR_NAME)
-    logger.debug(msg)
+    logger.debug(f"{VAR_NAME}: write complete, closing")
 
     cmor.close()
 
-    msg = "{}: file close complete".format(VAR_NAME)
-    logger.debug(msg)
+    logger.debug(f"{VAR_NAME}: file close complete")
 
-    return "orog"
+    return VARNAME

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -80,6 +80,7 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
 def remap(ds, pcode, mappingFileName, threshold=0.0):
     """Use ncreamp to remap the xarray Dataset to a new target grid"""
 
+    # TODO:  Make this a global commandline switch
     delete_tempfiles = True
 
     # write the dataset to a temp file
@@ -429,7 +430,8 @@ def write_cmor(axes, ds, varname, varunits, d2f=True, **kwargs):
     )
 
     # adding "shuffle" reduced size on disk by 14%, need to test for performance impact.
-    # if varname not in [ "lat", "lev", "lon" ]:
+    # TODO: Pass a commandline arg "--shuffle" down to this point.
+    # if do_shuffle and varname not in [ "lat", "lev", "lon" ]:
     #     cmor.set_deflate(varid, True, True, 1)
 
     # write out the data

--- a/scripts/example_end_to_end_script.sh
+++ b/scripts/example_end_to_end_script.sh
@@ -132,7 +132,6 @@ e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path}
 # 2. A restart file for meshes: can use the mpaso restart e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
 e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac, siu, siv, sithick, sisnthick, simass --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpassi_input/ --output-path ${result_dir} --user-metadata ${metadata_path}  --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
 
-
 # CMORIZE Ocean Monthly variables
 # Note the input folder for mpas ocean files requires:
 # 1. History files: e.g.,v2.LR.historical_0101.mpaso.hist.am.timeSeriesStatsMonthly.1850-01-01.nc
@@ -205,7 +204,7 @@ for ((segdex=0;segdex<range_segs;segdex++)); do
     ts=`date -u +%Y%m%d_%H%M%S_%6N`
     echo "$ts: Calling e3sm_to_cmip for segment years $year_init to $year_last" >> $runlog
 
-    # e3sm_to_cmip -s --realm Omon --var-list $Omon_var_list --map ${mapfile} --input-path ${native_data}  --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${tables_path} >> $runlog 2>&1
+    e3sm_to_cmip -s --realm Omon --var-list $Omon_var_list --map ${mapfile} --input-path ${native_data}  --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${tables_path} >> $runlog 2>&1
 
 done
 

--- a/scripts/example_end_to_end_script.sh
+++ b/scripts/example_end_to_end_script.sh
@@ -37,100 +37,6 @@ map_file=${e2c_path}/maps/map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
 tables_path=${e2c_path}/cmor/cmip6-cmor-tables/Tables/
 metadata_path=${e2c_path}/user_metadata.json
 
-# NOTE: Space is not accepted in nco var list
-## ------------------------------------------------------
-## TEST CASE - atm monthly h0
-## ------------------------------------------------------
-input_path=${model_data}/v2.eam_input
-flags='-7 --dfl_lvl=1 --no_cll_msr'
-raw_var_list="ICEFRAC,OCNFRAC,LANDFRAC,PHIS,hyam,hybm,hyai,hybi,TREFHT,TS,PSL,PS,U10,QREFHT,PRECC,PRECL,PRECSC,PRECSL,QFLX,TAUX,TAUY,LHFLX,CLDTOT,FLDS,FLNS,FSDS,FSNS,SHFLX,CLOUD,CLDICE,TGCLDIWP,CLDLIQ,TGCLDCWP,TMQ,FLNSC,FSNTOA,FSNT,FLNT,FLUTC,FSDSC,SOLIN,FSNSC,FSUTOA,FSUTOAC,AODABS,AODVIS,AREL,TREFMNAV,TREFMXAV,FISCCP1_COSP,CLDTOT_ISCCP,MEANCLDALB_ISCCP,MEANPTOP_ISCCP,CLD_CAL,CLDTOT_CAL,CLDLOW_CAL,CLDMED_CAL,CLDHGH_CAL"
-
-# 1. atm 2D variables
-#--------------------------
-cmip_var_list="pfull, phalf, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, cl, clw, cli, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin, clisccp, cltisccp, albisccp, pctisccp, clcalipso, cltcalipso, cllcalipso, clmcalipso, clhcalipso"
-ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
-# CMORIZE Atmosphere monthly variables: 2D and model level 3D variables (CLOUD,CLDICE,CLDLIQ)
-e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t $tables_path -u ${metadata_path}
-
-# 2. atm fixed variables
-#--------------------------
-raw_var_list="area,PHIS,LANDFRAC"
-cmip_var_list="areacella, sftlf, orog"
-ncremap --map=${map_file} -v area,PHIS,LANDFRAC -I ${input_path} -O ${rgr_dir}/fixed_vars
-
-# CMORIZE Atmosphere fx variables
-e3sm_to_cmip --realm fx -i ${rgr_dir}/fixed_vars -o $result_dir  -v areacella, sftlf, orog  -t ${tables_path} -u ${metadata_path}
-
-## ------------------------------------------------------
-## TEST CASE - atm 3D variables
-## ------------------------------------------------------
-flags='-7 --dfl_lvl=1 --no_cll_msr'
-raw_var_list="Q,O3,T,U,V,Z3,RELHUM,OMEGA"
-cmip_var_list="hur, hus, ta, ua, va, wap, zg, o3"
-ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir_vert} -v ${raw_var_list} -i ${input_path} ${flags}
-for file in `ls ${rgr_dir_vert}`
-do
-  ncks --rgr xtr_mth=mss_val --vrt_fl=${e2c_path}/grids/vrt_remap_plev19.nc ${rgr_dir_vert}/$file ${rgr_dir}/$file
-done
-
-# Note --start=$start --end=$end would not work with ncremap
-#ncremap -P eam -j 1 --xtr_mth=mss_val --vrt_fl=${e2c_path}/grids/vrt_remap_plev19.nc  -O ${rgr_dir} -v ${raw_var_list} -I ${rgr_dir_vert} ${flags}
-
-# CMORIZE Atmosphere monthly plev variables
-e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
-
-## ------------------------------------------------------
-## TEST CASE - atm high freq daily h1+
-## ------------------------------------------------------
-input_path=${model_data}/v2.eam.h1_input
-flags='-7 --dfl_lvl=1 --no_cll_msr --clm_md=hfs'
-raw_var_list="TREFHTMN,TREFHTMX,PRECT,TREFHT,FLUT,QREFHT"
-cmip_var_list="tasmin, tasmax, tas, huss, rlut, pr"
-rgr_dir=${result_dir}/rgr_day
-native_dir=${result_dir}/native_day
-ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
-
-# CMORIZE Atmosphere daily variables
-e3sm_to_cmip --freq day -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
-
-## ------------------------------------------------------
-## TEST CASE - atm high freq 3hrly h1+
-## ------------------------------------------------------
-input_path=${model_data}/v2.eam.h4_input
-flags='-7 --dfl_lvl=1 --no_cll_msr --clm_md=hfs'
-raw_var_list="PRECT"
-rgr_dir=${result_dir}/rgr_3hr
-native_dir=${result_dir}/native_3hr
-cmip_var_list="pr"
-ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
-
-# CMORIZE Atmosphere 3hrly variables
-e3sm_to_cmip --freq 3hr -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
-
-## ------------------------------------------------------
-## TEST CASE - land monthly h0
-## ------------------------------------------------------
-input_path=${model_data}/v2.elm_input/
-flags='-7 --dfl_lvl=1 --no_cll_msr'
-raw_var_list="LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO"
-cmip_var_list="mrsos, mrso, mrfso, mrros, mrro, prveg, evspsblveg, evspsblsoi, tran, tsl, lai"
-rgr_dir=${result_dir}/rgr_lnd
-native_dir=${result_dir}/native_lnd
-
-# Note either include the extra variable landfrac or specify the file that has landfrac for subgrid scale mode to work.
-ncclimo -P elm -j 1 --var_xtr=landfrac --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
-# Alternative ncclimo invocation
-#ncclimo -P elm -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags} --sgs_frc=${input_path}/v2.LR.historical_0101.elm.h0.1850-01.nc/landfrac
-
-#raw_var_list_elm_bgc="TOTLITC,CWDC,TOTPRODC,SOIL1C,SOIL2C,SOIL3C,^SOIL4C$,COL_FIRE_CLOSS,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
-# CMORIZE Land Monthly variables
-e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
-
-# CMORIZE Sea-ice Monthly variables
-# Note the input folder for mpas sea ice files requires:
-# 1. Monthly mean history files: e.g.,v2.LR.historical_0101.mpassi.hist.am.timeSeriesStatsMonthly.1850-01-01.nc
-# 2. A restart file for meshes: can use the mpaso restart e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
-e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac, siu, siv, sithick, sisnthick, simass --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpassi_input/ --output-path ${result_dir} --user-metadata ${metadata_path}  --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
 
 # CMORIZE Ocean Monthly variables
 # Note the input folder for mpas ocean files requires:
@@ -140,6 +46,79 @@ e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac
 #    hfsifrazil requires 'config_density0' and 'config_frazil_heat_of_fusion'
 # 3. A restart file for mesh: e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
 # 4. A region masks file for MOC regions: EC30to60E2r2_mocBasinsAndTransects20210623.nc (Needed for variable msftmz: Ocean Meridional Overturning Mass Streamfunction)
-e3sm_to_cmip -s --realm Omon --var-list areacello, fsitherm, hfds, masso, mlotst, sfdsi, sob, soga, sos, sosga, tauuo, tauvo, thetaoga, tob, tos, tosga, volo, wfo, zos, thetaoga, hfsifrazil, masscello, so, thetao, thkcello, uo, vo, volcello, wo, zhalfo --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpaso_input/ --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
+
+# BEYOND THIS POINT, We attempt to replace "${model_data}/v2.mpaso_input/" with a directory of symlinks ("native_data"), intended to support a
+# user-specified "years-per-file" (YPF) value, and to call e3sm_to_cmip on those lonks in a loop that updates the links for each YPF segment.
+
+ts=`date -u +%Y%m%d_%H%M%S_%6N`
+runlog="e2e_e2c-${ts}.log"
+
+Omon_var_list="areacello, fsitherm, hfds, masso, mlotst, sfdsi, sob, soga, sos, sosga, tauuo, tauvo, thetaoga, tob, tos, tosga, volo, wfo, zos, thetaoga, hfsifrazil, masscello, so, thetao, thkcello, uo, vo, volcello, wo, zhalfo"
+mapfile=${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
+
+native_src=${model_data}/v2.mpaso_input/
+
+in_count=`ls $native_src | wc -l`
+echo "NATIVE_SOURCE_COUNT=$in_count files ($((in_count / 12)) years)" >> $runlog 2>&1
+
+
+real_native_src=/p/user_pub/work/E3SM/2_0/historical/LR/ocean/native/model-output/mon/ens1/v20220806
+
+# Determine range of years and number of segments from the available native input (model_data).
+start_year=`ls $real_native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | head -1`
+final_year=`ls $real_native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | tail -1`
+range_years=$((10#$final_year - 10#$start_year + 1))
+ypf=20
+range_segs=$((range_years/ypf))
+if [[ $((range_segs*ypf)) -lt $range_years ]]; then range_segs=$((range_segs + 1)); fi
+
+
+native_data="native_links"
+mkdir -p $native_data
+rm $native_data/*
+
+# WORK:  To begin, we need symlinks in native_data to ALL files in model_output, because the restart, namefile and region_mask files are there.
+
+for afile in `ls $native_src`; do
+    ln -s ${native_src}/$afile $native_data/$afile 2>/dev/null
+done
+
+# for this test, remove links to these datafiles, because we will use the full published years.
+for afile in `ls ${native_data}/*mpaso.hist.am.timeSeriesStatsMonthly*.nc 2>/dev/null`; do
+    rm -f $afile
+done
+
+for ((segdex=0;segdex<range_segs;segdex++)); do
+
+    # wipe existing native_data datafile symlinks, create new range of same
+    # then create the next segment of symlinks, and call the e3sm_to_cmip
+
+    for afile in `ls ${native_data}/*mpaso.hist.am.timeSeriesStatsMonthly*.nc 2>/dev/null`; do
+        rm -f $afile
+    done
+
+    for ((yrdex=0;yrdex<ypf;yrdex++)); do
+        the_year=$((10#$start_year + segdex*ypf + yrdex))
+        prt_year=`printf "%04d" "$the_year"`
+
+        if [[ $the_year -gt $((10#$final_year)) ]]; then
+            break;
+        fi
+
+        for afile in `ls $real_native_src/*.${prt_year}-*.nc`; do
+            bfile=`basename $afile`
+            ln -s $afile $native_data/$bfile 2>/dev/null
+        done
+    done
+
+    year_init=$((10#$start_year + segdex*ypf))
+    year_last=$((10#$start_year + segdex*ypf + yrdex - 1))
+    ts=`date -u +%Y%m%d_%H%M%S_%6N`
+    echo "$ts: Calling e3sm_to_cmip for segment years $year_init to $year_last" >> $runlog
+
+    # e3sm_to_cmip -s --realm Omon --var-list $Omon_var_list --map ${mapfile} --input-path ${native_data}  --output-path ${result_dir} --user-metadata ${metadata_path} --tables-path ${tables_path} >> $runlog 2>&1
+
+done
+
 
 exit

--- a/scripts/example_end_to_end_script.sh
+++ b/scripts/example_end_to_end_script.sh
@@ -37,6 +37,104 @@ map_file=${e2c_path}/maps/map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
 tables_path=${e2c_path}/cmor/cmip6-cmor-tables/Tables/
 metadata_path=${e2c_path}/user_metadata.json
 
+# NOTE: Space is not accepted in nco var list
+## ------------------------------------------------------
+## TEST CASE - atm monthly h0
+## ------------------------------------------------------
+input_path=${model_data}/v2.eam_input
+flags='-7 --dfl_lvl=1 --no_cll_msr'
+raw_var_list="ICEFRAC,OCNFRAC,LANDFRAC,PHIS,hyam,hybm,hyai,hybi,TREFHT,TS,PSL,PS,U10,QREFHT,PRECC,PRECL,PRECSC,PRECSL,QFLX,TAUX,TAUY,LHFLX,CLDTOT,FLDS,FLNS,FSDS,FSNS,SHFLX,CLOUD,CLDICE,TGCLDIWP,CLDLIQ,TGCLDCWP,TMQ,FLNSC,FSNTOA,FSNT,FLNT,FLUTC,FSDSC,SOLIN,FSNSC,FSUTOA,FSUTOAC,AODABS,AODVIS,AREL,TREFMNAV,TRE
+FMXAV,FISCCP1_COSP,CLDTOT_ISCCP,MEANCLDALB_ISCCP,MEANPTOP_ISCCP,CLD_CAL,CLDTOT_CAL,CLDLOW_CAL,CLDMED_CAL,CLDHGH_CAL"
+
+# 1. atm 2D variables
+#--------------------------
+cmip_var_list="pfull, phalf, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, cl, clw, cli, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin, clisccp, cltisccp, albisccp, pctis
+ccp, clcalipso, cltcalipso, cllcalipso, clmcalipso, clhcalipso"
+ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
+# CMORIZE Atmosphere monthly variables: 2D and model level 3D variables (CLOUD,CLDICE,CLDLIQ)
+e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t $tables_path -u ${metadata_path}
+
+# 2. atm fixed variables
+#--------------------------
+raw_var_list="area,PHIS,LANDFRAC"
+cmip_var_list="areacella, sftlf, orog"
+ncremap --map=${map_file} -v area,PHIS,LANDFRAC -I ${input_path} -O ${rgr_dir}/fixed_vars
+
+# CMORIZE Atmosphere fx variables
+e3sm_to_cmip --realm fx -i ${rgr_dir}/fixed_vars -o $result_dir  -v areacella, sftlf, orog  -t ${tables_path} -u ${metadata_path}
+
+## ------------------------------------------------------
+## TEST CASE - atm 3D variables
+## ------------------------------------------------------
+flags='-7 --dfl_lvl=1 --no_cll_msr'
+raw_var_list="Q,O3,T,U,V,Z3,RELHUM,OMEGA"
+cmip_var_list="hur, hus, ta, ua, va, wap, zg, o3"
+ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir_vert} -v ${raw_var_list} -i ${input_path} ${flags}
+for file in `ls ${rgr_dir_vert}`
+do
+  ncks --rgr xtr_mth=mss_val --vrt_fl=${e2c_path}/grids/vrt_remap_plev19.nc ${rgr_dir_vert}/$file ${rgr_dir}/$file
+done
+
+# Note --start=$start --end=$end would not work with ncremap
+#ncremap -P eam -j 1 --xtr_mth=mss_val --vrt_fl=${e2c_path}/grids/vrt_remap_plev19.nc  -O ${rgr_dir} -v ${raw_var_list} -I ${rgr_dir_vert} ${flags}
+
+# CMORIZE Atmosphere monthly plev variables
+e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
+
+## ------------------------------------------------------
+## TEST CASE - atm high freq daily h1+
+## ------------------------------------------------------
+input_path=${model_data}/v2.eam.h1_input
+flags='-7 --dfl_lvl=1 --no_cll_msr --clm_md=hfs'
+raw_var_list="TREFHTMN,TREFHTMX,PRECT,TREFHT,FLUT,QREFHT"
+cmip_var_list="tasmin, tasmax, tas, huss, rlut, pr"
+rgr_dir=${result_dir}/rgr_day
+native_dir=${result_dir}/native_day
+ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
+
+# CMORIZE Atmosphere daily variables
+e3sm_to_cmip --freq day -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
+
+## ------------------------------------------------------
+## TEST CASE - atm high freq 3hrly h1+
+## ------------------------------------------------------
+input_path=${model_data}/v2.eam.h4_input
+flags='-7 --dfl_lvl=1 --no_cll_msr --clm_md=hfs'
+raw_var_list="PRECT"
+rgr_dir=${result_dir}/rgr_3hr
+native_dir=${result_dir}/native_3hr
+cmip_var_list="pr"
+ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
+
+# CMORIZE Atmosphere 3hrly variables
+e3sm_to_cmip --freq 3hr -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
+
+## ------------------------------------------------------
+## TEST CASE - land monthly h0
+## ------------------------------------------------------
+input_path=${model_data}/v2.elm_input/
+flags='-7 --dfl_lvl=1 --no_cll_msr'
+raw_var_list="LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO"
+cmip_var_list="mrsos, mrso, mrfso, mrros, mrro, prveg, evspsblveg, evspsblsoi, tran, tsl, lai"
+rgr_dir=${result_dir}/rgr_lnd
+native_dir=${result_dir}/native_lnd
+
+# Note either include the extra variable landfrac or specify the file that has landfrac for subgrid scale mode to work.
+ncclimo -P elm -j 1 --var_xtr=landfrac --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
+# Alternative ncclimo invocation
+#ncclimo -P elm -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags} --sgs_frc=${input_path}/v2.LR.historical_0101.elm.h0.1850-01.nc/landfrac
+
+#raw_var_list_elm_bgc="TOTLITC,CWDC,TOTPRODC,SOIL1C,SOIL2C,SOIL3C,^SOIL4C$,COL_FIRE_CLOSS,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+# CMORIZE Land Monthly variables
+e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path} -u ${metadata_path}
+
+# CMORIZE Sea-ice Monthly variables
+# Note the input folder for mpas sea ice files requires:
+# 1. Monthly mean history files: e.g.,v2.LR.historical_0101.mpassi.hist.am.timeSeriesStatsMonthly.1850-01-01.nc
+# 2. A restart file for meshes: can use the mpaso restart e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
+e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac, siu, siv, sithick, sisnthick, simass --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpassi_input/ --output-path ${result_dir} --user-metadata ${metadata_path}  --tables
+-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
+
 
 # CMORIZE Ocean Monthly variables
 # Note the input folder for mpas ocean files requires:
@@ -58,15 +156,9 @@ mapfile=${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
 
 native_src=${model_data}/v2.mpaso_input/
 
-in_count=`ls $native_src | wc -l`
-echo "NATIVE_SOURCE_COUNT=$in_count files ($((in_count / 12)) years)" >> $runlog 2>&1
-
-
-real_native_src=/p/user_pub/work/E3SM/2_0/historical/LR/ocean/native/model-output/mon/ens1/v20220806
-
 # Determine range of years and number of segments from the available native input (model_data).
-start_year=`ls $real_native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | head -1`
-final_year=`ls $real_native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | tail -1`
+start_year=`ls $native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | head -1`
+final_year=`ls $native_src | grep mpaso.hist.am.timeSeriesStatsMonthly | rev | cut -f2 -d. | rev | cut -f1 -d- | tail -1`
 range_years=$((10#$final_year - 10#$start_year + 1))
 ypf=20
 range_segs=$((range_years/ypf))
@@ -105,7 +197,7 @@ for ((segdex=0;segdex<range_segs;segdex++)); do
             break;
         fi
 
-        for afile in `ls $real_native_src/*.${prt_year}-*.nc`; do
+        for afile in `ls $native_src/*.${prt_year}-*.nc`; do
             bfile=`basename $afile`
             ln -s $afile $native_data/$bfile 2>/dev/null
         done

--- a/scripts/example_end_to_end_script.sh
+++ b/scripts/example_end_to_end_script.sh
@@ -43,13 +43,11 @@ metadata_path=${e2c_path}/user_metadata.json
 ## ------------------------------------------------------
 input_path=${model_data}/v2.eam_input
 flags='-7 --dfl_lvl=1 --no_cll_msr'
-raw_var_list="ICEFRAC,OCNFRAC,LANDFRAC,PHIS,hyam,hybm,hyai,hybi,TREFHT,TS,PSL,PS,U10,QREFHT,PRECC,PRECL,PRECSC,PRECSL,QFLX,TAUX,TAUY,LHFLX,CLDTOT,FLDS,FLNS,FSDS,FSNS,SHFLX,CLOUD,CLDICE,TGCLDIWP,CLDLIQ,TGCLDCWP,TMQ,FLNSC,FSNTOA,FSNT,FLNT,FLUTC,FSDSC,SOLIN,FSNSC,FSUTOA,FSUTOAC,AODABS,AODVIS,AREL,TREFMNAV,TRE
-FMXAV,FISCCP1_COSP,CLDTOT_ISCCP,MEANCLDALB_ISCCP,MEANPTOP_ISCCP,CLD_CAL,CLDTOT_CAL,CLDLOW_CAL,CLDMED_CAL,CLDHGH_CAL"
+raw_var_list="ICEFRAC,OCNFRAC,LANDFRAC,PHIS,hyam,hybm,hyai,hybi,TREFHT,TS,PSL,PS,U10,QREFHT,PRECC,PRECL,PRECSC,PRECSL,QFLX,TAUX,TAUY,LHFLX,CLDTOT,FLDS,FLNS,FSDS,FSNS,SHFLX,CLOUD,CLDICE,TGCLDIWP,CLDLIQ,TGCLDCWP,TMQ,FLNSC,FSNTOA,FSNT,FLNT,FLUTC,FSDSC,SOLIN,FSNSC,FSUTOA,FSUTOAC,AODABS,AODVIS,AREL,TREFMNAV,TREFMXAV,FISCCP1_COSP,CLDTOT_ISCCP,MEANCLDALB_ISCCP,MEANPTOP_ISCCP,CLD_CAL,CLDTOT_CAL,CLDLOW_CAL,CLDMED_CAL,CLDHGH_CAL"
 
 # 1. atm 2D variables
 #--------------------------
-cmip_var_list="pfull, phalf, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, cl, clw, cli, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin, clisccp, cltisccp, albisccp, pctis
-ccp, clcalipso, cltcalipso, cllcalipso, clmcalipso, clhcalipso"
+cmip_var_list="pfull, phalf, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, cl, clw, cli, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin, clisccp, cltisccp, albisccp, pctisccp, clcalipso, cltcalipso, cllcalipso, clmcalipso, clhcalipso"
 ncclimo -P eam -j 1 --map=${map_file} --start=$start --end=$end --ypf=$ypf --split -c $caseid -o ${native_dir} -O ${rgr_dir} -v ${raw_var_list} -i ${input_path} ${flags}
 # CMORIZE Atmosphere monthly variables: 2D and model level 3D variables (CLOUD,CLDICE,CLDLIQ)
 e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t $tables_path -u ${metadata_path}
@@ -132,8 +130,7 @@ e3sm_to_cmip -i ${rgr_dir} -o $result_dir  -v ${cmip_var_list} -t ${tables_path}
 # Note the input folder for mpas sea ice files requires:
 # 1. Monthly mean history files: e.g.,v2.LR.historical_0101.mpassi.hist.am.timeSeriesStatsMonthly.1850-01-01.nc
 # 2. A restart file for meshes: can use the mpaso restart e.g., v2.LR.historical_0101.mpaso.rst.1855-01-01_00000.nc
-e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac, siu, siv, sithick, sisnthick, simass --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpassi_input/ --output-path ${result_dir} --user-metadata ${metadata_path}  --tables
--path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
+e3sm_to_cmip -s --realm SImon --var-list siconc, sitemptop, sisnmass, sitimefrac, siu, siv, sithick, sisnthick, simass --map ${e2c_path}/maps/map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc --input-path ${model_data}/v2.mpassi_input/ --output-path ${result_dir} --user-metadata ${metadata_path}  --tables-path ${e2c_path}/cmor/cmip6-cmor-tables/Tables
 
 
 # CMORIZE Ocean Monthly variables


### PR DESCRIPTION
## Description

This is a feature addition to the example_end_to_end_script.sh".  The final section (mpaso CMIP generation) has been wrapped in codes that loop over the e2c call for each specified YPF segment of years.  The total years are still calculated by examining the user-supplied "model-output" directory, but now an intermediate directory (native_links) is employed, keeping the links to restart, namefile and regions-file, but creating (and destroying) symlinks to the datafiles, by YPF segment.

Changes have only been tested in "dry-run" (where the actual e3sm_to_cmip command is commented out) in order to test the YPF cycling (and logfile generation) alone.
