### PR TITLE
Fix masking of 3D MPAS-Ocean variables

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -238,10 +238,8 @@ def add_mask(ds, mask):
     for varName in ds.data_vars:
         var = ds[varName]
         if all([dim in var.dims for dim in mask.dims]):
+            print(f"Masking {varName}")
             ds[varName] = var.where(mask)
-            
-
-    ds["cellMask"] = 1.0 * mask
 
     return ds
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -225,7 +225,7 @@ def add_mask(ds, mask):
     for varName in ds.data_vars:
         var = ds[varName]
         if all([dim in var.dims for dim in mask.dims]):
-            ds[varName] = var.where(mask, 0.0)
+            ds[varName] = var.where(mask)
 
     ds["cellMask"] = 1.0 * mask
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -345,8 +345,7 @@ def open_mfdataset(
     return ds
 
 
-def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
-                 unlimited=None):
+def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals, unlimited=None):
     """Write an xarray Dataset with NetCDF4 fill values where needed"""
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
@@ -359,8 +358,7 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
             dtype = ds[variableName].dtype
             for fillType in fillValues:
                 if dtype == np.dtype(fillType):
-                    encodingDict[variableName] = \
-                        {"_FillValue": fillValues[fillType]}
+                    encodingDict[variableName] = {"_FillValue": fillValues[fillType]}
                     break
         else:
             encodingDict[variableName] = {"_FillValue": None}

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -119,6 +119,10 @@ def remap(ds, pcode, mappingFileName):
     if "depth" in ds.dims:
         ds = ds.transpose("time", "depth", "nCells", "nbnd")
 
+    # missing_value_mask attribute has undesired impacts in ncremap
+    for varName in ds.data_vars:
+        ds[varName].attrs.pop("missing_value_mask", None)
+
     write_netcdf(ds, inFileName, unlimited="time")
 
     if pcode == "mpasocean":
@@ -235,6 +239,7 @@ def add_mask(ds, mask):
         var = ds[varName]
         if all([dim in var.dims for dim in mask.dims]):
             ds[varName] = var.where(mask)
+            
 
     ds["cellMask"] = 1.0 * mask
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -344,9 +344,8 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals, unlimited=No
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for variableName in variableNames:
-        if "_FillValue" in ds[variableName].attrs:
-            # There's already a fill value attribute so don't add a new one
-            continue
+        # If there's already a fill value attribute, drop it
+        ds[variableName].attrs.pop("_FillValue", None)
         isNumeric = np.issubdtype(ds[variableName].dtype, np.number)
         if isNumeric:
             dtype = ds[variableName].dtype

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -232,24 +232,6 @@ def add_mask(ds, mask):
     return ds
 
 
-def add_si_mask(ds, mask, siconc, threshold=0.05):
-    """
-    Add a 2D mask to the data sets and apply the mask to all variables
-    """
-
-    mask = np.logical_and(mask, siconc > threshold)
-
-    ds = ds.copy()
-    for varName in ds.data_vars:
-        var = ds[varName]
-        if all([dim in var.dims for dim in mask.dims]):
-            ds[varName] = var.where(mask, 0.0)
-
-    ds["cellMask"] = 1.0 * mask
-
-    return ds
-
-
 def get_mpaso_cell_masks(dsMesh):
     """Get 2D and 3D masks of valid MPAS-Ocean cells from the mesh Dataset"""
 

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -141,8 +141,13 @@ def remap(ds, pcode, mappingFileName):
     ds.load()
 
     # remove the temporary files
-    os.remove(inFileName)
-    os.remove(outFileName)
+    keep_temp_files = False
+    if keep_temp_files:
+        logging.info(f"Retaining inFileName  {inFileName}")
+        logging.info(f"Retaining outFileName {outFileName}")
+    else:
+        os.remove(inFileName)
+        os.remove(outFileName)
 
     return ds
 


### PR DESCRIPTION
## Description

We have discovered that 3D ocean variables have not been correctly masked following https://github.com/E3SM-Project/e3sm_to_cmip/pull/155.  The review of that PR focused entirely on correctly masking sea-ice output and we missed the impact it had on 3D ocean variables, which was that is removed manual masking after remapping and assumed (incorrectly) that ncremap was handling the masking and renormaliztion itself.  Instead, the 3D fields were being set to zero (not the `_FillValue`) below bathymetry, leading to fractional values after remapping, as reported in https://github.com/E3SM-Project/E3SM/discussions/6546

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
