### PR TITLE
Consolidate cmor setup 273

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -4,8 +4,8 @@ compute  Grid-Cell Area for Ocean Variables areacello
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPAS_mesh', 'MPAS_map']
@@ -65,7 +65,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # area_b is in square radians, so need to multiply by the earth_radius**2
     ds[VAR_NAME] = earth_radius**2*area_b*ds[VAR_NAME]
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
                user_input_path=user_input_path)
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -60,7 +60,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -73,7 +73,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -76,7 +76,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -8,7 +8,7 @@ import xarray
 import logging
 import netCDF4
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map']
@@ -77,7 +77,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh']
@@ -69,7 +69,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -66,7 +66,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds = mpas.add_mask(ds, cellMask2D)
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPASO_MOC_regions', 'MPASO_namelist']
@@ -76,7 +76,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = ds.rename({'moc': VAR_NAME})
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     region = ['global_ocean',
               'atlantic_arctic_ocean']

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -84,7 +84,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPASO_namelist', 'MPAS_mesh', 'MPAS_map', 'PSL']
@@ -80,7 +80,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     with xarray.open_mfdataset(pslFileNames, concat_dim='time') as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -61,7 +61,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -63,7 +63,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -62,7 +62,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -9,7 +9,7 @@ import logging
 
 import xarray
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -66,7 +66,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -65,7 +65,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -69,7 +69,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASSI', 'MPAS_mesh', 'MPAS_map']
@@ -70,7 +70,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasseaice', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='seaice')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -70,7 +70,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -66,7 +66,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -61,7 +61,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -61,7 +61,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -70,7 +70,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds = mpas.add_time(ds, dsIn)
         ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -6,8 +6,8 @@ import xarray
 import logging
 import netCDF4
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 
@@ -71,7 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ds[VAR_NAME] = ds[VAR_NAME].where(
         ds[VAR_NAME] != netCDF4.default_fillvals['f4'], 0.)
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
                user_input_path=user_input_path)
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -66,7 +66,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
         ds.compute()
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -6,8 +6,8 @@ import xarray
 import logging
 import netCDF4
 
-from e3sm_to_cmip import mpas
-from e3sm_to_cmip.util import print_message, setup_cmor
+from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
 
@@ -85,7 +85,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
     # multiply variables in this order so they don't get transposed
     ds[VAR_NAME] = ds[VAR_NAME]*earth_radius**2*area_b
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
                user_input_path=user_input_path)
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh']
@@ -67,7 +67,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds.compute()
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_map']
@@ -71,7 +71,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -8,7 +8,7 @@ import xarray
 import logging
 import numpy
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -70,7 +70,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -8,7 +8,7 @@ import xarray
 import logging
 import numpy
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ['MPASO', 'MPAS_mesh', 'MPAS_map']
@@ -90,7 +90,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
     depth_coord_half = numpy.zeros(nVertLevels+1)
     depth_coord_half[1:] = dsMesh.refBottomDepth.values
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import xarray
 import logging
 
-from e3sm_to_cmip import mpas
+from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -69,7 +69,8 @@ def handle(infiles, tables, user_input_path, **kwargs):
 
     ds = mpas.remap(ds, 'mpasocean', mappingFileName)
 
-    mpas.setup_cmor(VAR_NAME, tables, user_input_path, component='ocean')
+    util.setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     # create axes
     axes = [{'table_entry': 'time',

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -399,27 +399,6 @@ def convert_namelist_to_dict(fileName):
     return nml
 
 
-def setup_cmor(varname, tables, user_input_path, component="ocean", table=None):
-    """Set up CMOR for MPAS-Ocean or MPAS-Seaice"""
-    logfile = os.path.join(os.getcwd(), "cmor_logs")
-    if not os.path.exists(logfile):
-        os.makedirs(logfile)
-    logfile = os.path.join(logfile, varname + ".log")
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-    cmor.dataset_json(str(user_input_path))
-    if table is None:
-        if component == "ocean":
-            table = "CMIP6_Omon.json"
-        elif component == "seaice":
-            table = "CMIP6_SImon.json"
-        else:
-            raise ValueError("Unexpected component {}".format(component))
-    try:
-        cmor.load_table(table)
-    except Exception:
-        raise ValueError("Unable to load table from {}".format(varname))
-
-
 def write_cmor(axes, ds, varname, varunits, d2f=True, **kwargs):
     """Write a time series of a variable in the format expected by CMOR"""
     axis_ids = list()


### PR DESCRIPTION
CMOR SETUP CONSOLIDATION:

(Addresses issue #273)

The motivation for cmor.setup reconfigurations is that this cmor function was called from 7 separate locations:

    the setup_cmor() in util.py
    the setup_cmor() in mpas.py
    the _setup_cmor_module() in handler.py
    and 4 raw calls to cmor.setup in the areacella.py, clisccp.py, orog.py and sftlf.py variable handlers.

Aside from unnecessary replication of codes, each call to cmor.setup invokes a cmor-internal "logger" setup, whose only external accessibility is the name of the logfile to supply. There is no ability to alter its propagate(True/False), date-format or other attributes. (I believe it is responsible for the "duplicated log messages" problem, as only those messages with the CMOR date-format appear to be duplicated.)
Describe the solution you'd like

Now, there are only TWO functions that invoke cmor.setup: util.setup_cmor(), and handler._setup_cmor_module(). The latter is applied to every handler managed through the "handlers.yaml" construct. The former handles all other variables. The function in mpas.py has been eliminated.
Describe alternatives you've considered

No response
Additional context

No response
