### PR TITLE
Additional refactoring of cmor setup for specific variables (`areacella`, `clisccp`, `orog`, `sftlf`)

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -78,8 +78,12 @@ def handle(infiles, tables, user_input_path, table, logdir):
         logpath = os.path.join(outpath, "cmor_logs")
     os.makedirs(logpath, exist_ok=True)
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-            user_input_path=user_input_path)
+    setup_cmor(
+        var_name=VAR_NAME,
+        table_path=tables,
+        table_name=TABLE,
+        user_input_path=user_input_path,
+    )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
     logger.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -16,7 +16,7 @@ from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
 
-logger = _setup_logger(name=__name__)
+logger = _setup_logger(__name__)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("area")]

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -56,13 +56,14 @@ def handle_simple(infiles):
 
 
 def handle(infiles, tables, user_input_path, table, logdir):
-    logger.info(f"{VAR_NAME}: Starting")
+    msg = "{}: Starting".format(VAR_NAME)
+    logger.info(msg)
 
     # check that we have some input files for every variable
     zerofiles = False
     for variable in RAW_VARIABLES:
         if len(infiles[variable]) == 0:
-            msg = f"{VARNAME}: Unable to find input files for {variable}"
+            msg = "{}: Unable to find input files for {}".format(VAR_NAME, variable)
             print_message(msg)
             logging.error(msg)
             zerofiles = True

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip import resources
+from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
 from e3sm_to_cmip.util import setup_cmor, print_message
 

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -14,7 +14,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import setup_cmor, print_message
+from e3sm_to_cmip.util import print_message, setup_cmor
 
 logger = _setup_logger(__name__)
 

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -12,11 +12,10 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip import resources
-from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
-logger = _setup_logger(__name__)
+logger = _setup_logger(name=__name__)
 
 # list of raw variable names needed
 RAW_VARIABLES = [str("area")]
@@ -56,14 +55,13 @@ def handle_simple(infiles):
 
 
 def handle(infiles, tables, user_input_path, table, logdir):
-    msg = "{}: Starting".format(VAR_NAME)
-    logger.info(msg)
+    logger.info(f"{VAR_NAME}: Starting")
 
     # check that we have some input files for every variable
     zerofiles = False
     for variable in RAW_VARIABLES:
         if len(infiles[variable]) == 0:
-            msg = "{}: Unable to find input files for {}".format(VAR_NAME, variable)
+            msg = f"{VARNAME}: Unable to find input files for {variable}"
             print_message(msg)
             logging.error(msg)
             zerofiles = True
@@ -78,15 +76,11 @@ def handle(infiles, tables, user_input_path, table, logdir):
         logpath = os.path.join(outpath, "cmor_logs")
     os.makedirs(logpath, exist_ok=True)
 
-    logfile = os.path.join(logpath, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-
-    cmor.dataset_json(str(user_input_path))
-    cmor.load_table(str(TABLE))
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
-    logging.info(msg)
+    logger.info(msg)
 
     # extract data from the input file
     msg = "areacella: loading area"

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -74,7 +74,12 @@ def handle(  # noqa: C901
     msg = f"{VAR_NAME}: running with input files: {vars_to_filepaths}"
     logger.debug(msg)
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=metadata_path)
+    setup_cmor(
+        var_name=VAR_NAME,
+        table_path=tables,
+        table_name=TABLE,
+        user_input_path=metadata_path,
+    )
 
     msg = f"{VAR_NAME}: CMOR setup complete"
     logger.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -14,7 +14,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip._logger import _setup_logger
-from e3sm_to_cmip.util import setup_cmor, print_message
+from e3sm_to_cmip.util import print_message, setup_cmor
 
 logger = _setup_logger(__name__)
 

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -14,7 +14,7 @@ import xarray as xr
 
 import cmor
 from e3sm_to_cmip._logger import _setup_logger
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
 logger = _setup_logger(__name__)
 
@@ -74,17 +74,7 @@ def handle(  # noqa: C901
     msg = f"{VAR_NAME}: running with input files: {vars_to_filepaths}"
     logger.debug(msg)
 
-    if logdir is not None:
-        logfile = logfile = os.path.join(logdir, VAR_NAME + ".log")
-    else:
-        logfile = os.path.join(os.getcwd(), "logs")
-        if not os.path.exists(logfile):
-            os.makedirs(logfile)
-        logfile = os.path.join(logfile, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-    cmor.dataset_json(metadata_path)
-    cmor.load_table(TABLE)
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE, user_input_path=metadata_path)
 
     msg = f"{VAR_NAME}: CMOR setup complete"
     logger.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -70,8 +70,12 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-            user_input_path=user_input_path)
+    setup_cmor(
+        var_name=VAR_NAME,
+        table_path=tables,
+        table_name=TABLE,
+        user_input_path=user_input_path,
+    )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
     logging.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -14,7 +14,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
 logger = _setup_logger(__name__)
 
@@ -70,20 +70,8 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    # Create the logging directory and setup cmor
-    if logdir:
-        logpath = logdir
-    else:
-        outpath, _ = os.path.split(logger.__dict__["handlers"][0].baseFilename)
-        logpath = os.path.join(outpath, "cmor_logs")
-    os.makedirs(logpath, exist_ok=True)
-
-    logfile = os.path.join(logpath, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-
-    cmor.dataset_json(str(user_input_path))
-    cmor.load_table(str(TABLE))
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
     logging.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -14,7 +14,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import setup_cmor, print_message
+from e3sm_to_cmip.util import print_message, setup_cmor
 
 logger = _setup_logger(__name__)
 

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -69,8 +69,12 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
-            user_input_path=user_input_path)
+    setup_cmor(
+        var_name=VAR_NAME,
+        table_path=tables,
+        table_name=TABLE,
+        user_input_path=user_input_path,
+    )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
     logging.info(msg)

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -14,7 +14,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import setup_cmor, print_message
+from e3sm_to_cmip.util import print_message, setup_cmor
 
 logger = _setup_logger(__name__)
 

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -14,7 +14,7 @@ import cmor
 from e3sm_to_cmip import resources
 from e3sm_to_cmip._logger import _setup_logger
 from e3sm_to_cmip.mpas import write_netcdf
-from e3sm_to_cmip.util import print_message
+from e3sm_to_cmip.util import setup_cmor, print_message
 
 logger = _setup_logger(__name__)
 
@@ -69,20 +69,8 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    # Create the logging directory and setup cmor
-    if logdir:
-        logpath = logdir
-    else:
-        outpath, _ = os.path.split(logger.__dict__["handlers"][0].baseFilename)
-        logpath = os.path.join(outpath, "cmor_logs")
-    os.makedirs(logpath, exist_ok=True)
-
-    logfile = os.path.join(logpath, VAR_NAME + ".log")
-
-    cmor.setup(inpath=tables, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
-
-    cmor.dataset_json(str(user_input_path))
-    cmor.load_table(str(TABLE))
+    setup_cmor(var_name=VAR_NAME, table_path=tables, table_name=TABLE,
+            user_input_path=user_input_path)
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)
     logging.info(msg)


### PR DESCRIPTION
## Description

This re-addresses issue #273.

When separating the cmor consolidation material from the logging redesign, I neglected to include the four variable handlers still listed under "vars" (areacella.py, clisccp.py, orog.py, and sftlf.py).  Rather than re-open that branch, I created this one.

