### PR TITLE
Tweak behaviours of build workflow

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  CANCEL_OTHERS: true
+  CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**", "**/examples/**", "**/misc/**", "**/.vscode/**", "**/ISSUE_TEMPLATE/**", "**/pull_request_template.md"]'
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
   #   needs: skip-duplicate-actions
   #   if: needs.skip-duplicate-actions.outputs.should_skip != 'true'
   #   runs-on: ubuntu-latest
-  #   timeout-minutes: 3
+  #   timeout-minutes: 5
   #   steps:
   #     - name: Checkout Code Repository
   #       uses: actions/checkout@v3
@@ -63,11 +63,9 @@ jobs:
       - name: Set up Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: "e3sm_to_cmip_ci"
-          use-mamba: true
-          mamba-version: "*"
           channel-priority: strict
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -94,10 +92,10 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Update environment
         run: |
-          mamba env update -n e3sm_to_cmip_ci -f conda-env/ci.yml
+          conda env update -n e3sm_to_cmip_ci -f conda-env/ci.yml
           # Make sure the Python version in the env matches the current matrix version.
           # Make sure numpy is not > 2.0.
-          mamba install -c conda-forge python=${{ matrix.python-version }} "numpy>=1.23.0,<2.0"
+          conda install -c conda-forge python=${{ matrix.python-version }} "numpy>=1.23.0,<2.0"
 
       - name: Install e3sm_to_cmip
         # Source: https://github.com/conda/conda-build/issues/4251#issuecomment-1053460542


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Hello! I am making this PR to bring in a few CI changes @xylar and I have been implementing across other repos. These changes include:
1. `cancel_others` is now set to false by default, which should make it easier to decipher if a bug is isolated to a specific version of python via CI
2. All references to `mamba`/`Mambaforge` have been removed and/or changed to `conda` and `Miniforge3`
3. The timeout for the `pre-commit` job has been upped to 5 minutes (we were having jobs occasionally run out of time during the caching step)

For the `pre-commit` change, I just upped the number in the comment where the current `pre-commit` settings are listed, but I didn't un-comment anything.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
