### PR TITLE
[Bug]: Fix logger and CMOR logs directory used by MPAS handlers

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -178,8 +178,8 @@ class VarHandler(BaseVarHandler):
         vars_to_filepaths: Dict[str, List[str]],
         tables_path: str,
         metadata_path: str,
+        cmor_log_dir: str,
         table: str | None = None,
-        logdir: str | None = None,
     ) -> bool:
         """CMORizes a list of E3SM raw variables to a CMIP variable.
 
@@ -191,11 +191,11 @@ class VarHandler(BaseVarHandler):
             The path to directory containing CMOR Tables directory.
         metadata_path : str
             The path to user json file for CMIP6 metadata
+        cmor_log_dir : str
+            The directory that stores the CMOR logs.
         table : str | None
             The CMOR table filename, derived from a custom `freq`, by default
             None.
-        logdir : str | None, optional
-            The optional CMOR logging directory, by default None
 
         Returns
         -------
@@ -215,7 +215,7 @@ class VarHandler(BaseVarHandler):
         # Create the logging directory and setup the CMOR module globally before
         # running any CMOR functions.
         # ----------------------------------------------------------------------
-        self._setup_cmor_module(self.name, tables_path, metadata_path, logdir)
+        self._setup_cmor_module(self.name, tables_path, metadata_path, cmor_log_dir)
 
         # Get parameters for running CMOR operations
         # ----------------------------------------------------------------------
@@ -294,11 +294,7 @@ class VarHandler(BaseVarHandler):
         return True
 
     def _setup_cmor_module(
-        self,
-        var_name: str,
-        tables_path: str,
-        metadata_path: str,
-        log_dir: str | None,
+        self, var_name: str, tables_path: str, metadata_path: str, cmor_log_dir: str
     ):
         """Set up the CMOR module before CMORzing variables.
 
@@ -312,17 +308,10 @@ class VarHandler(BaseVarHandler):
             The tables path.
         metadata_path : str
             The metadata path.
-        logdir : str | None
-            The optional log directory.
+        cmor_log_dir : str
+            The directory that stores the CMOR logs.
         """
-        if log_dir is not None:
-            logpath = log_dir
-        else:
-            cwd = os.getcwd()
-            logpath = os.path.join(cwd, "cmor_logs")
-
-        os.makedirs(logpath, exist_ok=True)
-        logfile = os.path.join(logpath, var_name + ".log")
+        logfile = os.path.join(cmor_log_dir, var_name + ".log")
 
         cmor.setup(
             inpath=tables_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/areacello.py
@@ -2,11 +2,10 @@
 compute  Grid-Cell Area for Ocean Variables areacello
 """
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -18,7 +17,10 @@ VAR_UNITS = "m2"
 TABLE = "CMIP6_Ofx.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO cellArea into CMIP.areacello
     Parameters
@@ -43,7 +45,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -72,6 +74,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/fsitherm.py
@@ -4,11 +4,10 @@ compute Water Flux into Sea Water due to Sea Ice Thermodynamics, fsitherm
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg m-2 s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_seaIceFreshWaterFlux into CMIP.fsitherm
 
@@ -44,7 +46,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f"Simple CMOR output not supported for {VAR_NAME}", "error")
         return None
 
-    logging.info(f"Starting {VAR_NAME}")
+    logger.info(f"Starting {VAR_NAME}")
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -69,6 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfds.py
@@ -4,11 +4,10 @@ compute Downward Heat Flux at Sea Water Surface, hfds
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "W m-2"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_seaIceHeatFlux,
     timeMonthly_avg_latentHeatFlux ,timeMonthly_avg_sensibleHeatFlux,
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f"Simple CMOR output not supported for {VAR_NAME}", "error")
         return None
 
-    logging.info(f"Starting {VAR_NAME}")
+    logger.info(f"Starting {VAR_NAME}")
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -84,6 +86,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/hfsifrazil.py
@@ -4,11 +4,10 @@ compute Heat Flux into Sea Water due to Frazil Ice Formation, hfsifrazil
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "W m-2"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_frazilLayerThicknessTendency into
     CMIP.hfsifrazil
@@ -45,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         print_message(f"Simple CMOR output not supported for {VAR_NAME}", "error")
         return None
 
-    logging.info(f"Starting {VAR_NAME}")
+    logger.info(f"Starting {VAR_NAME}")
 
     timeSeriesFiles = infiles["MPASO"]
     mappingFileName = infiles["MPAS_map"]
@@ -87,6 +89,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masscello.py
@@ -4,12 +4,11 @@ compute Ocean Grid-Cell Mass per area, masscello
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import netCDF4
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -21,7 +20,10 @@ VAR_UNITS = "kg m-2"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.masscello
 
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles["MPASO_namelist"]
     meshFileName = infiles["MPAS_mesh"]
@@ -89,6 +91,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/masso.py
@@ -4,11 +4,10 @@ compute Sea Water Mass, masso
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.masso
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles["MPASO_namelist"]
     meshFileName = infiles["MPAS_mesh"]
@@ -79,6 +81,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -10,8 +10,6 @@ from e3sm_to_cmip import mpas, util
 from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
-logger = _setup_child_logger(__name__)
-
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ["MPASO", "MPAS_mesh", "MPAS_map"]
 
@@ -19,8 +17,6 @@ RAW_VARIABLES = ["MPASO", "MPAS_mesh", "MPAS_map"]
 VAR_NAME = "mlotst"
 VAR_UNITS = "m"
 TABLE = "CMIP6_Omon.json"
-
-logger = _setup_child_logger(__name__)
 
 
 logger = _setup_child_logger(__name__)

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/mlotst.py
@@ -20,8 +20,13 @@ VAR_NAME = "mlotst"
 VAR_UNITS = "m"
 TABLE = "CMIP6_Omon.json"
 
+logger = _setup_child_logger(__name__)
 
-def handle(infiles, tables, user_input_path, **kwargs):
+
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_dThreshMLD into CMIP.mlotst
 
@@ -29,12 +34,12 @@ def handle(infiles, tables, user_input_path, **kwargs):
     ----------
     infiles : dict
         a dictionary with namelist, mesh and time series file names
-
     tables : str
         path to CMOR tables
-
     user_input_path : str
         path to user input json file
+    cmor_log_dir : str
+        path to directory where CMOR log files will be stored.
 
     Returns
     -------
@@ -77,6 +82,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/msftmz.py
@@ -4,11 +4,10 @@ compute Ocean Meridional Overturning Mass Streamfunction, msftmz
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_normalVelocity,
     timeMonthly_avg_normalGMBolusVelocity, timeMonthly_avg_vertVelocityTop,
@@ -49,7 +51,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -87,6 +89,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     region = ["global_ocean", "atlantic_arctic_ocean"]

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -4,11 +4,10 @@ compute Sea Water Pressure at Sea floor, pbo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "Pa"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_pressureAdjustedSSH, timeMonthly_avg_ssh,
     timeMonthly_avg_density, timeMonthly_avg_layerThickness, and EAM PSL into
@@ -48,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles["MPASO_namelist"]
     meshFileName = infiles["MPAS_mesh"]
@@ -96,6 +98,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -4,11 +4,10 @@ compute Sea Water Pressure at Sea Water Surface, pso
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "Pa"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_pressureAdjustedSSH and
     timeMonthly_avg_ssh, and EAM PSL into CMIP.pso
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     namelistFileName = infiles["MPASO_namelist"]
     meshFileName = infiles["MPAS_mesh"]
@@ -93,6 +95,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sfdsi.py
@@ -4,11 +4,10 @@ compute Downward Sea Ice Basal Salt Flux, sfdsi
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg m-2 s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_seaIceSalinityFlux into CMIP.sfdsi
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -71,6 +73,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siconc.py
@@ -4,11 +4,10 @@ Sea-ice area fraction, siconc
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "%"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell into CMIP.siconc
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -71,6 +73,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/simass.py
@@ -4,11 +4,10 @@ Sea-ice mass per area, simass
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ["MPASSI", "MPAS_mesh", "MPAS_map"]
@@ -19,7 +18,10 @@ VAR_UNITS = "kg m-2"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell and
     timeMonthly_avg_iceVolumeCell into CMIP.simass
@@ -41,7 +43,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         the name of the processed variable after processing is complete
     """
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -69,6 +71,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnmass.py
@@ -4,11 +4,10 @@ Snow mass per area, sisnmass
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg m-2"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell and
     timeMonthly_avg_snowVolumeCell into CMIP.sisnmass
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -75,6 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sisnthick.py
@@ -4,11 +4,10 @@ Snow thickness, sisnthick
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell and
     timeMonthly_avg_snowVolumeCell into CMIP.sisnthick
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -75,6 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitemptop.py
@@ -4,11 +4,10 @@ Surface temperature of sea ice, sitemptop
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "K"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell and
     timeMonthly_avg_surfaceTemperatureCell into CMIP.sitemptop
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -73,6 +75,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sithick.py
@@ -4,11 +4,10 @@ Sea-ice thickness, sithick
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_iceAreaCell and
     timeMonthly_avg_iceVolumeCell into CMIP.sithick
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -73,6 +75,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sitimefrac.py
@@ -4,11 +4,10 @@ Fraction of time steps with sea ice, sitimefrac
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "1"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_icePresent into CMIP.sitimefrac
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASSI"]
@@ -74,6 +76,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siu.py
@@ -4,11 +4,10 @@ X-component of sea ice velocity, siu
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m s-1"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_uVelocityGeo into CMIP.siu
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -78,6 +80,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/siv.py
@@ -4,11 +4,10 @@ Y-component of sea ice velocity, siv
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m s-1"
 TABLE = "CMIP6_SImon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASSI timeMonthly_avg_vVelocityGeo into CMIP.siv
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -80,6 +82,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/so.py
@@ -4,11 +4,10 @@ compute Sea Water Salinity, so
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "0.001"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.so
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sob.py
@@ -4,11 +4,10 @@ compute Sea Water Salinity at Sea Floor, sob
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 
 # 'MPAS' as a placeholder for raw variables needed
 RAW_VARIABLES = ["MPASO", "MPAS_mesh", "MPAS_map"]
@@ -19,7 +18,10 @@ VAR_UNITS = "0.001"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sob
 
@@ -45,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -76,6 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/soga.py
@@ -4,11 +4,10 @@ compute Global Mean Sea Water Salinity, soga
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "0.001"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness and
     timeMonthly_avg_activeTracers_salinity into CMIP.soga
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -78,6 +80,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sos.py
@@ -4,11 +4,10 @@ compute Sea Surface Salinity, sos
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "0.001"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sos
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/sosga.py
@@ -4,11 +4,10 @@ compute Global Average Sea Surface Salinity, sosga
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "0.001"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_salinity into CMIP.sosga
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -75,6 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauuo.py
@@ -4,11 +4,10 @@ compute Surface Downward X Stress, tauuo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "N m-2"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_windStressZonal into CMIP.tauuo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -71,6 +73,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tauvo.py
@@ -4,11 +4,10 @@ compute Surface Downward Y Stress, tauvo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "N m-2"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_windStressMeridional into CMIP.tauvo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -71,6 +73,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetao.py
@@ -4,11 +4,10 @@ compute Sea Water Potential Temperature, thetao
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "degC"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.thetao
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thetaoga.py
@@ -4,11 +4,10 @@ compute Global Average Sea Water Potential Temperature, thetaoga
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "degC"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness and
     timeMonthly_avg_activeTracers_temperature into CMIP.thetaoga
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -78,6 +80,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/thkcello.py
@@ -2,12 +2,11 @@
 compute Ocean Model Cell Thickness, thkcello
 """
 
-import logging
-
 import netCDF4
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,7 +18,10 @@ VAR_UNITS = "m"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.thkcello
 
@@ -45,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -81,6 +83,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tob.py
@@ -4,11 +4,10 @@ compute Sea Water Potential Temperature at Sea Floor, tob
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "degC"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tob
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tos.py
@@ -4,11 +4,10 @@ compute Sea Surface Temperature, tos
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "degC"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tos
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/tosga.py
@@ -4,11 +4,10 @@ compute Global Average Sea Surface Temperature, tosga
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "degC"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_activeTracers_temperature into CMIP.tosga
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -75,6 +77,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/uo.py
@@ -4,11 +4,10 @@ compute Sea Water X Velocity, uo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_velocityZonal into CMIP.uo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/vo.py
@@ -4,11 +4,10 @@ compute Sea Water Y Velocity, vo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_velocityMeridional into CMIP.vo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -77,6 +79,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volcello.py
@@ -2,12 +2,11 @@
 compute Ocean Grid-Cell Volume, volcello
 """
 
-import logging
-
 import netCDF4
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -19,7 +18,10 @@ VAR_UNITS = "m3"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.thkcello
 
@@ -45,7 +47,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -96,6 +98,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/volo.py
@@ -4,11 +4,10 @@ compute Sea Water Volume, volo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m3"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.volo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     timeSeriesFiles = infiles["MPASO"]
@@ -76,6 +78,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wfo.py
@@ -4,11 +4,10 @@ compute Water Flux into Sea Water, wfo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "kg m-2 s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_seaIceFreshWaterFlux,
     timeMonthly_avg_riverRunoffFlux, timeMonthly_avg_iceRunoffFlux,
@@ -48,7 +50,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     mappingFileName = infiles["MPAS_map"]
     timeSeriesFiles = infiles["MPASO"]
@@ -83,6 +85,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/wo.py
@@ -4,11 +4,10 @@ compute Sea Water Vertical Velocity, wo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m s-1"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_vertVelocityTop into CMIP.wo
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -79,6 +81,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zhalfo.py
@@ -4,12 +4,11 @@ compute 	Depth Below Geoid of Interfaces Between Ocean Layers, zhalfo
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import numpy
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -21,7 +20,10 @@ VAR_UNITS = "m"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_layerThickness into CMIP.zhalfo
 
@@ -47,7 +49,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -101,6 +103,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/zos.py
@@ -4,11 +4,10 @@ compute Sea Surface Height Above Geoid, zos
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import xarray
 
 from e3sm_to_cmip import mpas, util
+from e3sm_to_cmip._logger import _setup_child_logger
 from e3sm_to_cmip.util import print_message
 
 # 'MPAS' as a placeholder for raw variables needed
@@ -20,7 +19,10 @@ VAR_UNITS = "m"
 TABLE = "CMIP6_Omon.json"
 
 
-def handle(infiles, tables, user_input_path, **kwargs):
+logger = _setup_child_logger(__name__)
+
+
+def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
     """
     Transform MPASO timeMonthly_avg_pressureAdjustedSSH into CMIP.zos
 
@@ -46,7 +48,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         return
 
     msg = "Starting {name}".format(name=__name__)
-    logging.info(msg)
+    logger.info(msg)
 
     meshFileName = infiles["MPAS_mesh"]
     mappingFileName = infiles["MPAS_map"]
@@ -78,6 +80,7 @@ def handle(infiles, tables, user_input_path, **kwargs):
         table_path=tables,
         table_name=TABLE,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     # create axes

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -75,8 +75,8 @@ def handle(infiles, tables, user_input_path, cmor_log_dir, table):
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
-        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)

--- a/e3sm_to_cmip/cmor_handlers/vars/areacella.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/areacella.py
@@ -56,7 +56,7 @@ def handle_simple(infiles):
     write_netcdf(ds, outname, fillValues=fillVals, unlimited=["time"])
 
 
-def handle(infiles, tables, user_input_path, table, logdir):
+def handle(infiles, tables, user_input_path, cmor_log_dir, table):
     msg = "{}: Starting".format(VAR_NAME)
     logger.info(msg)
 
@@ -71,18 +71,11 @@ def handle(infiles, tables, user_input_path, table, logdir):
     if zerofiles:
         return None
 
-    # Create the logging directory and setup cmor
-    if logdir:
-        logpath = logdir
-    else:
-        outpath, _ = os.path.split(logger.__dict__["handlers"][0].baseFilename)
-        logpath = os.path.join(outpath, "cmor_logs")
-    os.makedirs(logpath, exist_ok=True)
-
     setup_cmor(
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
+        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
     )
 

--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -29,8 +29,8 @@ def handle(  # noqa: C901
     vars_to_filepaths: Dict[str, List[str]],
     tables: str,
     metadata_path: str,
+    cmor_log_dir: str,
     table: str | None,
-    logdir: str | None,
 ) -> str | None:
     """Transform E3SM.TS into CMIP.ts
 
@@ -47,11 +47,11 @@ def handle(  # noqa: C901
         The path to directory containing CMOR Tables directory.
     metadata_path : str
         The path to user json file for CMIP6 metadata
+    cmor_log_dir : str
+            The directory that stores the CMOR logs.
     table : str | None
         The CMOR table filename, derived from a custom `freq`, by default
         None.
-    logdir : str | None, optional
-        The optional CMOR logging directory, by default None.
 
     Returns
     -------
@@ -79,6 +79,7 @@ def handle(  # noqa: C901
         table_path=tables,
         table_name=TABLE,
         user_input_path=metadata_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     msg = f"{VAR_NAME}: CMOR setup complete"

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -56,7 +56,7 @@ def handle_simple(infiles):
     write_netcdf(ds, outname, fillValues=fillVals, unlimited=["time"])
 
 
-def handle(infiles, tables, user_input_path, table, logdir):
+def handle(infiles, tables, user_input_path, cmor_log_dir, table):
     msg = f"{VAR_NAME}: Starting"
     logger.info(msg)
 
@@ -75,6 +75,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
+        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
     )
 

--- a/e3sm_to_cmip/cmor_handlers/vars/orog.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/orog.py
@@ -75,8 +75,8 @@ def handle(infiles, tables, user_input_path, cmor_log_dir, table):
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
-        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -55,7 +55,7 @@ def handle_simple(infiles):
     write_netcdf(ds, outname, fillValues=fillVals, unlimited=["time"])
 
 
-def handle(infiles, tables, user_input_path, table, logdir):
+def handle(infiles, tables, user_input_path, cmor_log_dir, table):
     msg = f"{VAR_NAME}: Starting"
     logger.info(msg)
 
@@ -74,6 +74,7 @@ def handle(infiles, tables, user_input_path, table, logdir):
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
+        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
     )
 

--- a/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/sftlf.py
@@ -74,8 +74,8 @@ def handle(infiles, tables, user_input_path, cmor_log_dir, table):
         var_name=VAR_NAME,
         table_path=tables,
         table_name=TABLE,
-        cmor_log_dir=cmor_log_dir,
         user_input_path=user_input_path,
+        cmor_log_dir=cmor_log_dir,
     )
 
     msg = "{}: CMOR setup complete".format(VAR_NAME)

--- a/e3sm_to_cmip/runner.py
+++ b/e3sm_to_cmip/runner.py
@@ -622,7 +622,6 @@ class E3SMtoCMIP:
                             vars_to_filepaths,
                             self.tables_path,
                             self.new_metadata_path,
-                            handler_table,
                             self.cmor_log_dir,
                             handler_table,
                         )

--- a/e3sm_to_cmip/runner.py
+++ b/e3sm_to_cmip/runner.py
@@ -90,7 +90,7 @@ class CLIArguments:
     info_out: Optional[str]
 
     precheck: Optional[str]
-    logdir: Optional[str]
+    logdir: str
     user_metadata: Optional[str]
     custom_metadata: Optional[str]
 
@@ -140,7 +140,7 @@ class E3SMtoCMIP:
         self.map_path: Optional[str] = parsed_args.map
         self.info_out_path: Optional[str] = parsed_args.info_out
         self.precheck_path: Optional[str] = parsed_args.precheck
-        self.cmor_log_dir: Optional[str] = parsed_args.logdir
+        self.cmor_log_dir: str = parsed_args.logdir
         self.user_metadata: Optional[str] = parsed_args.user_metadata
         self.custom_metadata: Optional[str] = parsed_args.custom_metadata
 
@@ -427,6 +427,7 @@ class E3SMtoCMIP:
         """
         self.new_metadata_path = os.path.join(self.output_path, "user_metadata.json")  # type: ignore
         self.cmor_log_dir = os.path.join(self.output_path, self.cmor_log_dir)  # type: ignore
+        os.makedirs(self.cmor_log_dir, exist_ok=True)
 
         # NOTE: Any warnings that appear before the log filehandler is
         # instantiated will not be captured (e.g,. esmpy VersionWarning).
@@ -614,6 +615,7 @@ class E3SMtoCMIP:
                             vars_to_filepaths,
                             self.tables_path,
                             self.new_metadata_path,
+                            self.cmor_log_dir,
                         )
                     else:
                         is_cmor_successful = handler_method(
@@ -622,6 +624,7 @@ class E3SMtoCMIP:
                             self.new_metadata_path,
                             handler_table,
                             self.cmor_log_dir,
+                            handler_table,
                         )
                 except TypeError as te:
                     logger.error(f"TypeError in handler '{handler['name']}': {te}")
@@ -694,6 +697,7 @@ class E3SMtoCMIP:
                         vars_to_filepaths,
                         self.tables_path,
                         self.new_metadata_path,
+                        self.cmor_log_dir,
                     )
                 else:
                     future = pool.submit(
@@ -701,8 +705,8 @@ class E3SMtoCMIP:
                         vars_to_filepaths,
                         self.tables_path,
                         self.new_metadata_path,
-                        handler_table,
                         self.cmor_log_dir,
+                        handler_table,
                     )
             except Exception as exc:
                 logger.error(

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -114,7 +114,8 @@ def setup_cmor(var_name, table_path, table_name, user_input_path, cmor_log_dir):
     Sets up cmor and logging for a single handler.
 
     NOTE: This function is only used by the MPAS variable handlers defined
-    under ``e3sm_to_cmip/cmor_handlers/mpas_vars``.
+    under ``e3sm_to_cmip/cmor_handlers/mpas_vars`` and legacy handlers
+    defined under ``e3sm_to_cmip/cmor_handlers/vars``.
     """
     logfile = os.path.join(cmor_log_dir, var_name + ".log")
     cmor.setup(inpath=table_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)

--- a/e3sm_to_cmip/util.py
+++ b/e3sm_to_cmip/util.py
@@ -109,20 +109,14 @@ def print_message(message, status="error"):
 # ------------------------------------------------------------------
 
 
-def setup_cmor(var_name, table_path, table_name, user_input_path):
+def setup_cmor(var_name, table_path, table_name, user_input_path, cmor_log_dir):
     """
-    Sets up cmor and logging for a single handler
+    Sets up cmor and logging for a single handler.
+
+    NOTE: This function is only used by the MPAS variable handlers defined
+    under ``e3sm_to_cmip/cmor_handlers/mpas_vars``.
     """
-    var_name = str(var_name)
-    table_path = str(table_path)
-    table_name = str(table_name)
-    user_input_path = str(user_input_path)
-
-    logfile = os.path.join(os.getcwd(), "logs")
-    if not os.path.exists(logfile):
-        os.makedirs(logfile)
-
-    logfile = os.path.join(logfile, var_name + ".log")
+    logfile = os.path.join(cmor_log_dir, var_name + ".log")
     cmor.setup(inpath=table_path, netcdf_file_action=cmor.CMOR_REPLACE, logfile=logfile)
 
     cmor.dataset_json(user_input_path)

--- a/scripts/debug/298-mpas-logs/mvce_mpas_success_serial.py
+++ b/scripts/debug/298-mpas-logs/mvce_mpas_success_serial.py
@@ -10,7 +10,7 @@ import os
 
 from e3sm_to_cmip.main import main
 
-OUTPUT_PATH = "/lcrc/group/e3sm/public_html/e3sm_to_cmip/298-logs-success-serial-mpas"
+OUTPUT_PATH = "/lcrc/group/e3sm/public_html/e3sm_to_cmip/298-test-mpas-cmor-logs"
 
 args = [
     "--var-list",

--- a/scripts/debug/298-mpas-logs/mvce_success_serial.py
+++ b/scripts/debug/298-mpas-logs/mvce_success_serial.py
@@ -24,7 +24,7 @@ from e3sm_to_cmip.main import main
 VAR_LIST = "tas, "
 
 # The output path for CMORized datasets. Update as needed.
-OUTPUT_PATH = "/lcrc/group/e3sm/public_html/e3sm_to_cmip/298-logs-success-serial"
+OUTPUT_PATH = "/lcrc/group/e3sm/public_html/e3sm_to_cmip/298-test-cmor-logs"
 
 
 args = [


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->



This PR updates all legacy MPAS handlers (defined as `.py` files in `mpas_vars`):
1. Instantiate and use the correct child logging instance (via `_logger._setup_child_logger()`.
   - Example: https://web.lcrc.anl.gov/public/e3sm/e3sm_to_cmip/298-test-mpas-cmor-logs/20250527_220356_311423.log
2. Use the same CMOR logs directory as `land` and `atm` variables -- defined via `--logdir` parameter (default is `<output_path>/cmor_logs`
   - Example: https://web.lcrc.anl.gov/public/e3sm/e3sm_to_cmip/298-test-mpas-cmor-logs/cmor_logs/

This ensures that all log messages are saved in the central `e3sm_to_cmip` log file and all CMOR logs are saved in the same CMOR logs directory.

- Closes #298 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
