### PR TITLE
Make each MPAS temp directory unique

### DIFF
--- a/e3sm_to_cmip/runner.py
+++ b/e3sm_to_cmip/runner.py
@@ -440,18 +440,16 @@ class E3SMtoCMIP:
         if not self.simple_mode and not self.info_mode:
             copy_user_metadata(self.user_metadata, self.output_path)
 
+        # Temporary directory for MPAS processing (e.g., regridding).
+        self.temp_path = None
         if not self.info_mode:
-            self.temp_path = os.environ.get("TMPDIR")
+            # Make temp_path unique by appending the process ID
+            self.temp_path = f"{self.output_path}/tmp_{os.getpid()}"
 
-            if self.temp_path is None:
-                self.temp_path = f"{self.output_path}/tmp"
-
-                if not os.path.exists(self.temp_path):
-                    os.makedirs(self.temp_path, exist_ok=True)
+            if not os.path.exists(self.temp_path):
+                os.makedirs(self.temp_path, exist_ok=True)
 
             tempfile.tempdir = self.temp_path
-        else:
-            self.temp_path = None
 
     def _run_info_mode(self):  # noqa: C901
         messages = []


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #308

In [v1.11.3](https://github.com/E3SM-Project/e3sm_to_cmip/blob/7321be009ff0626e31b1715175d948d7b05d6cc6/e3sm_to_cmip/__main__.py#L640-L647) and [v1.12.0](https://github.com/E3SM-Project/e3sm_to_cmip/blob/88f9373ca20a52de5f73723f197fd8b9e7f3d0b3/e3sm_to_cmip/runner.py#L443-L452), the temporary directory used for MPAS processing is either set with the 1) TMPDIR env variable or 2) the `{output_path}/tmp`. Temporary files (e.g., regridding with `mpas.remap()`) have unique names. 

However, even with unique filenames, sharing the same tmp dir across srun jobs can cause hangs on HPC filesystems like NFS/Lustre/GPFS.

- Multiple jobs writing in the same dir create metadata contention.
- HDF5/NetCDF writes still trigger dir-level locks.
- Some libs drop temp/helper files with non-unique names.

Fix: give each job its own tmp dir, and each rank a subdir (ideally on $SLURM_TMPDIR):

```bash
export JOB_TMP=$SCRATCH/e3sm_to_cmip/${SLURM_JOB_ID}
srun bash -lc 'export TMPDIR=${JOB_TMP}/rank_${SLURM_PROCID}; mkdir -p $TMPDIR; cd $TMPDIR; e3sm_to_cmip ...'
```

This removes possible resource contention and avoids hidden collisions.

## Other Info

- Why does the same logic work in v1.11.3 but not v1.12.0 (@TonyB9000 [comment](https://github.com/E3SM-Project/e3sm_to_cmip/issues/308#issuecomment-3180470327))
- Maybe we didn't run into this issue with v1.11.3 because processing was done on acme1?


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
