### PR TITLE
Fix areacello handler unlimited dimensions error

### DIFF
--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -124,7 +124,9 @@ def remap(ds, pcode, mappingFileName):
     for varName in ds.data_vars:
         ds[varName].attrs.pop("missing_value_mask", None)
 
-    write_netcdf(ds, inFileName, unlimited="time")
+    # Only set time as unlimited if it exists in the dataset dimensions
+    unlimited_dims = "time" if "time" in ds.dims else None
+    write_netcdf(ds, inFileName, unlimited=unlimited_dims)
 
     if pcode == "mpasocean":
         remap_ocean(inFileName, outFileName, mappingFileName)


### PR DESCRIPTION
Fixes issue where areacello processing fails with "Unlimited dimension(s) {'time'} declared in 'unlimited_dims-kwarg', but not part of current dataset dimensions" error.

The remap() function was unconditionally setting 'time' as an unlimited dimension, but areacello datasets don't have a time dimension since they represent time-invariant ocean cell areas. Now checks if 'time' dimension exists before setting it as unlimited.

Fixes #317

🤖 Generated with [Claude Code](https://claude.ai/code)



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
