### PR TITLE
Preserve legacy Xarray `compat` and `join` settings

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/handler.py
+++ b/e3sm_to_cmip/cmor_handlers/handler.py
@@ -390,6 +390,12 @@ class VarHandler(BaseVarHandler):
             combine="nested",
             data_vars="minimal",
             coords="minimal",
+            # NOTE: Preserve legacy Xarray behavior by setting compat="no_conflicts"
+            # and join="outer" ("override" and "exact" are the new defaults as of
+            # Xarray v2025.08.0). These settings are automatically set when
+            # using xcdat>=0.10.1.
+            compat="no_conflicts",
+            join="outer",
         )
 
         # If the output CMIP variable has an alternative time dimension name (e.g.,

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pbo.py
@@ -88,7 +88,12 @@ def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
 
     ds = mpas.remap(ds, "mpasocean", mappingFileName)
 
-    with xarray.open_mfdataset(pslFileNames, concat_dim="time") as dsIn:
+    # NOTE: Preserve legacy Xarray behavior by setting compat="no_conflicts"
+    # and join="outer" ("override" and "exact" are the new defaults as of
+    # Xarray v2025.08.0)
+    with xarray.open_mfdataset(
+        pslFileNames, concat_dim="time", compat="no_conflicts", join="outer"
+    ) as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
     util.setup_cmor(

--- a/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
+++ b/e3sm_to_cmip/cmor_handlers/mpas_vars/pso.py
@@ -85,7 +85,12 @@ def handle(infiles, tables, user_input_path, cmor_log_dir, **kwargs):
 
     ds = mpas.remap(ds, "mpasocean", mappingFileName)
 
-    with xarray.open_mfdataset(pslFileNames, concat_dim="time") as dsIn:
+    # NOTE: Preserve legacy Xarray behavior by setting compat="no_conflicts"
+    # and join="outer" ("override" and "exact" are the new defaults as of
+    # Xarray v2025.08.0)
+    with xarray.open_mfdataset(
+        pslFileNames, concat_dim="time", compat="no_conflicts", join="exact"
+    ) as dsIn:
         ds[VAR_NAME] = ds[VAR_NAME] + dsIn.PSL.values
 
     util.setup_cmor(

--- a/e3sm_to_cmip/mpas.py
+++ b/e3sm_to_cmip/mpas.py
@@ -76,7 +76,14 @@ def remap_seaice_sgs(inFileName, outFileName, mappingFileName, renorm_threshold=
         run_ncremap_cmd(args, env)
     # With  data_vars='minimal', only data variables in which the dimension already appears are included.
     ds_out_all = xarray.open_mfdataset(
-        f"{outFilePath}/temp_out*nc", data_vars="minimal", decode_times=False
+        f"{outFilePath}/temp_out*nc",
+        data_vars="minimal",
+        decode_times=False,
+        # NOTE: Preserve legacy Xarray behavior by setting compat="no_conflicts"
+        # and join="outer" ("override" and "exact" are the new defaults as of
+        # Xarray v2025.08.0)
+        compat="no_conflicts",
+        join="outer",
     )
     ds_out_all = ds_out_all.drop("timeMonthly_avg_iceAreaCell")
     ds_out_all.to_netcdf(outFileName)
@@ -326,6 +333,11 @@ def open_mfdataset(
         concat_dim="Time",
         mask_and_scale=False,
         chunks=chunks,
+        # NOTE: Preserve legacy Xarray behavior by setting compat="no_conflicts"
+        # and join="outer" ("override" and "exact" are the new defaults as of
+        # Xarray v2025.08.0).
+        compat="no_conflicts",
+        join="outer",
     )
 
     if variableList is not None:


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Related to https://github.com/E3SM-Project/e3sm_to_cmip/pull/307#issuecomment-3357451239

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
