### PR TITLE
Replace np.nan with FILL_VALUE in `clisccp.py` for cmor.write

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
+++ b/e3sm_to_cmip/cmor_handlers/vars/clisccp.py
@@ -11,6 +11,7 @@ import numpy as np
 import xarray as xr
 
 from e3sm_to_cmip._logger import _setup_child_logger
+from e3sm_to_cmip.cmor_handlers import FILL_VALUE
 from e3sm_to_cmip.util import print_message, setup_cmor
 
 logger = _setup_child_logger(__name__)
@@ -156,12 +157,10 @@ def handle(  # noqa: C901
 
         varid = cmor.variable(VAR_NAME, VAR_UNITS, axis_ids)
 
-        # replace NaNs in data with appropriate fill-value
-        FILL_VALUE = 1.e20
+        # Replace NaNs in data with appropriate fill-value for cmor.write,
+        # which does not support np.nan as a fill value.
         data["FISCCP1_COSP"] = np.where(
-            np.isnan(data["FISCCP1_COSP"]),
-            FILL_VALUE,
-            data["FISCCP1_COSP"]
+            np.isnan(data["FISCCP1_COSP"]), FILL_VALUE, data["FISCCP1_COSP"]
         )
 
         # write out the data


### PR DESCRIPTION
## Description

The v3.LR cases failed to support the CMIP6 variable `CFmon.clisccp" due to NaNs in the data where the standard FILL_Value was expected. Code is supplied in the cmor_handlers/vars/clisccp.py module that forces the replacement with the required FILL_Value, prior to calling cmor.write().

- Closes #326

## Checklist

- [y] My code follows the style guidelines of this project
- [y] I have performed a self-review of my own code
- [?] My changes generate no new warnings
- [na] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
