### PR TITLE
Fix bug: parallel mode incorrectly stops on handler failure when --on_var_failure=ignore

### DIFF
--- a/e3sm_to_cmip/runner.py
+++ b/e3sm_to_cmip/runner.py
@@ -931,7 +931,7 @@ class E3SMtoCMIP:
                 future_result, handler_name, num_handlers, num_success, failed_handlers
             )
 
-            if not future_result:
+            if not future_result and self.on_var_failure == "stop":
                 self._stop_with_failed_handler_parallel(
                     handler_name, pool, pbar, futures
                 )


### PR DESCRIPTION
## Problem:
- The parallel execution path was calling _stop_with_failed_handler_parallel() unconditionally whenever a handler failed, regardless of the --on-var-failure setting. See errors in /home/ac.forsyth2/copied_from_compy/e3sm_unified_1.13.0rc5_test_logs/rlut_failures
- This caused processes to stop immediately even when --on-var-failure=ignore (default) was set, breaking the expected behavior where failures should be ignored
- The serial execution path correctly checked the setting before stopping

## Solution:
- Add conditional check before calling _stop_with_failed_handler_parallel()
- Now only stops when self.on_var_failure == "stop", matching serial behavior
- Restores the default behavior where missing input files don't stop processing

This fixes the regression where runs that worked before v1.14.0 (with missing variables like PS) now incorrectly fail in parallel mode. **The fix essentially restores the "best effort" behavior that users expected, where missing some variables doesn't prevent processing the available ones.**



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
