### PR TITLE
Bump to v1.14.0

### DIFF
--- a/e3sm_to_cmip/__init__.py
+++ b/e3sm_to_cmip/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for e3sm_to_cmip."""
 
-__version__ = "1.14.0rc2"  # pragma: no cover
+__version__ = "1.14.0"  # pragma: no cover
 
 import os
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/e3sm_to_cmip"
 
 [version]
-current = "1.14.0rc2"
+current = "1.14.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## Summary

- Bumps version from `1.14.0rc2` to `1.14.0` (final release)
- Updates `tbump.toml` and `e3sm_to_cmip/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)