### PR TITLE
Extra eamxx var

### DIFF
--- a/e3sm_to_cmip/cmor_handlers/_formulas.py
+++ b/e3sm_to_cmip/cmor_handlers/_formulas.py
@@ -612,10 +612,16 @@ def rtmt(ds: xr.Dataset) -> xr.DataArray:
         result = ds["FSNT"] - ds["FLNT"]
     elif all(
         key in ds.data_vars
-        for key in ["SW_flux_dn_at_model_top", "SW_flux_up_at_model_top", "LW_flux_up_at_model_top"]
+        for key in [
+            "SW_flux_dn_at_model_top",
+            "SW_flux_up_at_model_top",
+            "LW_flux_up_at_model_top",
+        ]
     ):
         result = (
-            ds["SW_flux_dn_at_model_top"] - ds["SW_flux_up_at_model_top"] - ds["LW_flux_up_at_model_top"]
+            ds["SW_flux_dn_at_model_top"]
+            - ds["SW_flux_up_at_model_top"]
+            - ds["LW_flux_up_at_model_top"]
         )
     else:
         raise KeyError(
@@ -625,6 +631,7 @@ def rtmt(ds: xr.Dataset) -> xr.DataArray:
         )
 
     return result
+
 
 def tran(ds: xr.Dataset) -> xr.DataArray:
     """

--- a/e3sm_to_cmip/cmor_handlers/_formulas.py
+++ b/e3sm_to_cmip/cmor_handlers/_formulas.py
@@ -603,11 +603,28 @@ def rsutcs(ds: xr.Dataset) -> xr.DataArray:
 def rtmt(ds: xr.Dataset) -> xr.DataArray:
     """
     rtmt = FSNT - FLNT
+
+    EAMxx version:
+    pr = SW_flux_dn_at_model_top - SW_flux_up_at_model_top - LW_flux_up_at_model_top
     """
-    result = ds["FSNT"] - ds["FLNT"]
+
+    if all(key in ds.data_vars for key in ["FSNT", "FLNT"]):
+        result = ds["FSNT"] - ds["FLNT"]
+    elif all(
+        key in ds.data_vars
+        for key in ["SW_flux_dn_at_model_top", "SW_flux_up_at_model_top", "LW_flux_up_at_model_top"]
+    ):
+        result = (
+            ds["SW_flux_dn_at_model_top"] - ds["SW_flux_up_at_model_top"] - ds["LW_flux_up_at_model_top"]
+        )
+    else:
+        raise KeyError(
+            "No formula could be applied for 'rtmt'. Check the handler entry for 'rtmt' "
+            "and input file(s) contain either 'FSNT' and 'FLNT',"
+            "'SW_flux_dn_at_model_top', 'SW_flux_up_at_model_top' and 'LW_flux_up_at_model_top'. "
+        )
 
     return result
-
 
 def tran(ds: xr.Dataset) -> xr.DataArray:
     """

--- a/e3sm_to_cmip/cmor_handlers/_formulas.py
+++ b/e3sm_to_cmip/cmor_handlers/_formulas.py
@@ -625,9 +625,10 @@ def rtmt(ds: xr.Dataset) -> xr.DataArray:
         )
     else:
         raise KeyError(
-            "No formula could be applied for 'rtmt'. Check the handler entry for 'rtmt' "
-            "and input file(s) contain either 'FSNT' and 'FLNT',"
-            "'SW_flux_dn_at_model_top', 'SW_flux_up_at_model_top' and 'LW_flux_up_at_model_top'. "
+            "No formula could be applied for 'rtmt'. Check that the handler entry "
+            "for 'rtmt' and the input file(s) contain either 'FSNT' and 'FLNT', "
+            "or 'SW_flux_dn_at_model_top', 'SW_flux_up_at_model_top', and "
+            "'LW_flux_up_at_model_top'."
         )
 
     return result

--- a/e3sm_to_cmip/cmor_handlers/_formulas.py
+++ b/e3sm_to_cmip/cmor_handlers/_formulas.py
@@ -605,7 +605,7 @@ def rtmt(ds: xr.Dataset) -> xr.DataArray:
     rtmt = FSNT - FLNT
 
     EAMxx version:
-    pr = SW_flux_dn_at_model_top - SW_flux_up_at_model_top - LW_flux_up_at_model_top
+    rtmt = SW_flux_dn_at_model_top - SW_flux_up_at_model_top - LW_flux_up_at_model_top
     """
 
     if all(key in ds.data_vars for key in ["FSNT", "FLNT"]):

--- a/e3sm_to_cmip/cmor_handlers/handlers.yaml
+++ b/e3sm_to_cmip/cmor_handlers/handlers.yaml
@@ -1274,6 +1274,42 @@
   formula: null
   positive: null
   levels: null
+# --- 10m zonal wind component---
+- name: uas
+  units: m s-1
+  raw_variables: [U_at_10m_above_surface]
+  table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
+# --- 10m meridional wind component---
+- name: vas
+  units: m s-1
+  raw_variables: [V_at_10m_above_surface]
+  table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
+# --- cloud ---
+- name: cltisccp
+  units: "%"
+  raw_variables: [isccp_cldtot]
+  table: CMIP6_CFmon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
+# -- surface pressure--
+- name: ps
+  units: Pa
+  raw_variables: [ps]
+  table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: null
+  positive: null
+  levels: null
 # --- Sea-level pressure ---
 - name: psl
   units: Pa
@@ -1323,6 +1359,14 @@
   unit_conversion: null
   formula: null
   positive: up
+  levels: null
+- name: rtmt
+  units: W m-2
+  raw_variables: [SW_flux_dn_at_model_top, SW_flux_up_at_model_top, LW_flux_up_at_model_top]
+  table: CMIP6_Amon.json
+  unit_conversion: null
+  formula: SW_flux_dn_at_model_top - SW_flux_up_at_model_top - LW_flux_up_at_model_top
+  positive: down
   levels: null
 # --- Surface radiation ---
 - name: rsds


### PR DESCRIPTION
## Description

This PR adds additional EAMxx variable mappings needed by the PCMDI diagnostics workflow.

The newly supported variables map existing EAMxx output fields to the CMIP-style variable names expected downstream by `e3sm_to_cmip`, `zppy`, and PCMDI diagnostics.

Added mappings:

- `uas` from `U_at_10m_above_surface`
- `vas` from `V_at_10m_above_surface`
- `cltisccp` from `isccp_cldtot`
- `ps` from `ps`

These additions allow PCMDI diagnostics to access near-surface wind, ISCCP total cloud fraction, and surface pressure fields from EAMxx output using the expected CMIP variable names.

- Closes #<ISSUE_NUMBER_HERE>

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes locally
